### PR TITLE
コントローラーの名称を修正

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,4 +1,4 @@
-class LineBotController < ApplicationController
+class LinebotController < ApplicationController
     skip_before_action :verify_authenticity_token
 
     def callback


### PR DESCRIPTION
本番環境にデプロイしたところエラーが出たので、疑いのある箇所を修正

notifiacation_controller.rbにLINEBOT関連のコードが書かれていたが、改めてlinebot_controller.rbとnotifications_controller.rbに分け、さらにclientアクションをapplication_controller.rbに記述することで複数のコントローラーで呼び出せるように変更した。
その際にclass LineBotController < ApplicationControllerとなっていたため、line_bot_controller.rbと混在してしまったことが原因と仮説をたて、今回の修正を行なった。