### PR TITLE
通知予定日をモーダル上から編集する機能を実装

### DIFF
--- a/app/controllers/frameable.rb
+++ b/app/controllers/frameable.rb
@@ -1,0 +1,10 @@
+module Frameable
+    extend ActiveSupport::Concern
+
+    private
+
+    # リクエストがTurboフレーム経由かどうかを判定
+    def ensure_turbo_frame_response
+        redirect_to items_path unless turbo_frame_request?
+    end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,7 +21,7 @@ class ItemsController < ApplicationController
       if @item.save
         next_notification_day = @item.calculate_next_notification_day
         notification_interval = @item.calculate_interval(next_notification_day)
-      # オブジェクトを初期化
+        # オブジェクトを初期化
         @item.create_notification(
           next_notification_day: next_notification_day,
           notification_interval: notification_interval

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,5 +1,5 @@
 class LinebotController < ApplicationController
-    require 'line/bot'
+    require "line/bot"
 
     skip_before_action :verify_authenticity_token
 
@@ -23,7 +23,7 @@ class LinebotController < ApplicationController
 
     def push_message(user_id, message)
         client.push_message(user_id, {
-            type: 'text',
+            type: "text",
             text: message
         })
     end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -8,9 +8,28 @@ class NotificationsController < ApplicationController
     def update
         if @notification.update(notification_params)
             @notification.notification_update_next_notification_day(@notification.next_notification_day)
-            redirect_to items_path, notice: "通知日を更新しました"
+            respond_to do |format|
+                format.turbo_stream do
+                    render turbo_stream: turbo_stream.update( 
+                        "notification_#{@notification.id}", 
+                        partial: "modal", 
+                        locals: { notification: @notification }
+                        )
+                        binding.pry
+                end
+                format.html { redirect_to items_path, notice: "通知予定日を更新しました" }
+            end
         else
-            render :edit, status: :unprocessable_entity
+            respond_to do |format|
+                format.turbo_stream do
+                    render turbo_stream: turbo_stream.replace( 
+                            "modal", 
+                            partial: "notification/modal", 
+                            locals: { notification: @notification }
+                        ), status: :unprocessable_entity
+                end
+                format.html { render :edit, status: :unprocessable_entity }
+            end
         end
     end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -12,10 +12,9 @@ class NotificationsController < ApplicationController
                 format.turbo_stream do
                     render turbo_stream: turbo_stream.update( 
                         "notification_#{@notification.id}", 
-                        partial: "modal", 
+                        partial: "notifications/modal", 
                         locals: { notification: @notification }
                         )
-                        binding.pry
                 end
                 format.html { redirect_to items_path, notice: "通知予定日を更新しました" }
             end
@@ -24,7 +23,7 @@ class NotificationsController < ApplicationController
                 format.turbo_stream do
                     render turbo_stream: turbo_stream.replace( 
                             "modal", 
-                            partial: "notification/modal", 
+                            partial: "notifications/modal", 
                             locals: { notification: @notification }
                         ), status: :unprocessable_entity
                 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -12,8 +12,8 @@ class NotificationsController < ApplicationController
             @notification.notification_update_next_notification_day(@notification.next_notification_day)
             respond_to do |format|
                 format.turbo_stream do
-                    render turbo_stream: turbo_stream.update( 
-                        "notification_#{@notification.id}", 
+                    render turbo_stream: turbo_stream.update(
+                        "notification_#{@notification.id}",
                         partial: "notifications/modal",
                         locals: { notification: @notification }
                         )

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -14,7 +14,7 @@ class NotificationsController < ApplicationController
                 format.turbo_stream do
                     render turbo_stream: turbo_stream.update( 
                         "notification_#{@notification.id}", 
-                        partial: "notifications/modal", 
+                        partial: "notifications/modal",
                         locals: { notification: @notification }
                         )
                 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,6 +1,8 @@
 class NotificationsController < ApplicationController
-    before_action :authenticate_user!
+    include Frameable
 
+    before_action :authenticate_user!
+    before_action :ensure_turbo_frame_response, only: %w[edit]
     before_action :set_notification, only: [ :edit, :update ]
 
     def edit; end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -22,13 +22,6 @@ class NotificationsController < ApplicationController
             end
         else
             respond_to do |format|
-                format.turbo_stream do
-                    render turbo_stream: turbo_stream.replace( 
-                            "modal", 
-                            partial: "notifications/modal", 
-                            locals: { notification: @notification }
-                        ), status: :unprocessable_entity
-                end
                 format.html { render :edit, status: :unprocessable_entity }
             end
         end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("hello", HelloController)
 
 import ItemsController from "./items_controller"
 application.register("items", ItemsController)
+
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  connect() {
+    this.element.focus();
+  }
+
+  hide(event) {
+    event.preventDefault();
+
+    this.element.remove();
+  }
+
+  hideOnSubmit(event) {
+    if (event.detail.success) {
+      this.hide();
+    }
+  }
+
+  disconnect() {
+    this.#modalTurboFrame.src = null;
+  }
+
+  // private
+
+  get #modalTurboFrame() {
+    return document.querySelector("turbo-frame[id='modal']");
+  }
+}

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
+  static targets = ["modal"]
   // コントローラー接続で呼び出される
   connect() {
     this.element.focus();
@@ -18,6 +19,11 @@ export default class extends Controller {
     if (event && event.detail.success) {
       this.hide();
     }
+  }
+
+// モーダルをDOMから削除
+  hide() {
+    this.element.remove(); 
   }
 
   //モーダルが閉じられると発火

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,6 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
-
-// Connects to data-controller="modal"
 export default class extends Controller {
   // コントローラー接続で呼び出される
   connect() {
@@ -17,7 +15,7 @@ export default class extends Controller {
 
   //フォーム送信が終わるとモーダルを非表示
   hideOnSubmit(event) {
-    if (event.detail.success) {
+    if (event && event.detail.success) {
       this.hide();
     }
   }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -2,28 +2,37 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="modal"
 export default class extends Controller {
+  // コントローラー接続で呼び出される
   connect() {
     this.element.focus();
   }
 
+  // モーダルを非表示
   hide(event) {
     event.preventDefault();
 
+    //DOMからモーダルを削除
     this.element.remove();
   }
 
+  //フォーム送信が終わるとモーダルを非表示
   hideOnSubmit(event) {
     if (event.detail.success) {
       this.hide();
     }
   }
 
+  //モーダルが閉じられると発火
   disconnect() {
-    this.#modalTurboFrame.src = null;
+    if (this.element) {
+      //モーダルが閉じられたときにTurboフレームのsrc属性をnullに設定
+      this.#modalTurboFrame.src = null;
+    }
   }
 
   // private
 
+  // Turbo flame要素を取得
   get #modalTurboFrame() {
     return document.querySelector("turbo-frame[id='modal']");
   }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -51,7 +51,6 @@ class Item < ApplicationRecord
         message = "#{self.name}の残量が少なくなっています\n"
         message += " メモ: #{self.memo}\n" if self.memo.present?
         message += "https://stockmate-a7c103b7b0ba.herokuapp.com/\n"
-        Rails.logger.debug("生成された通知メッセージ: #{message}")  
         message
     end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -41,7 +41,7 @@ class Notification < ApplicationRecord
   def valid_update_next_notification_day
     if next_notification_day.blank?
       errors.add(:next_notification_day, :blank_field)
-    elsif next_notification_day < Date.today# + 1.days
+    elsif next_notification_day < Date.today + 1.days
       errors.add(:next_notification_day, :past_date)
     elsif next_notification_day > Date.today + 365.days
       errors.add(:next_notification_day, :too_far)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -19,7 +19,7 @@
               </div>
               <div class="flex flex-auto justify-center items-center mt-1">
                 <p class="text-3xl">次回の通知日 : </p>
-                <p class="text-3xl font-bold text-red-600"> <%= item.notification.next_notification_day %></p>
+                <p id="notification_#{@notification.id}" class="text-3xl font-bold text-red-600"><%= item.notification.next_notification_day %></p>
               </div>
               <div class="absolute top-2 right-2 flex space-x-2">
                 <div class="flex justify-end space-x-6">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -17,8 +17,9 @@
               <div class="flex justify-center items-center my-2">
                 <p class="text-lg">商品名 : <%= item.name %></p>
               </div>
-              <div id="notification_<%= item.notification.id %>">
-                <%= render "notifications/modal", notification: item.notification %>
+              <div class="flex flex-auto justify-center items-center mt-1">
+                <p class="text-3xl">次回の通知日 : </p>
+                <p id=<%= "notification_#{item.notification.id}" %> class="text-3xl font-bold text-red-600"><%= item.notification.next_notification_day %></p>
               </div>
               <div class="absolute top-2 right-2 flex space-x-2">
                 <div class="flex justify-end space-x-6">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,21 +6,24 @@
       <% if @items.present? %>
       <ul class="space-y-5">
         <% @items.each do |item| %>
-          <div class="flex bg-base-300 shadow-lg shadow-lg rounded-lg">
+          <div class="flex bg-base-300 shadow-lg rounded-lg">
             <a href="<%= item_path(item) %>", class="flex-shrink-0 hidden md:block hover:shadow-xl transition-shadow">
               <img class="rounded-lg w-56 border-4 border-base-300" src="https://picsum.photos/300/180" alt="<%= item.name %>">
             </a>
-            <div class="ml-6 flex-grow relative flex flex-col justify-center items-start h-32">
+            <div class="ml-6 flex-grow relative flex flex-col justify-center items-center h-32">
               <div class="flex justify-center items-center mb-1">
                 <p class="text-2xl">カテゴリー : <%= t("categories.#{item.category}") %></p>
               </div>
+
               <div class="flex justify-center items-center my-2">
                 <p class="text-lg">商品名 : <%= item.name %></p>
               </div>
+
               <div class="flex flex-auto justify-center items-center mt-1">
                 <p class="text-3xl">次回の通知日 : </p>
                 <p id=<%= "notification_#{item.notification.id}" %> class="text-3xl font-bold text-red-600"><%= item.notification.next_notification_day %></p>
               </div>
+
               <div class="absolute top-2 right-2 flex space-x-2">
                 <div class="flex justify-end space-x-6">
                   <%= link_to edit_notification_path(item), data: {turbo_frame: "modal"}, class: "text-gray-500 hover:text-gray-700" do %>
@@ -34,6 +37,7 @@
                   <% end %>
                 </div>
               </div>
+
             </div>
           </div>
         <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -23,7 +23,7 @@
               </div>
               <div class="absolute top-2 right-2 flex space-x-2">
                 <div class="flex justify-end space-x-6">
-                  <%= link_to edit_notification_path(item), class: "text-gray-500 hover:text-gray-700" do %>
+                  <%= link_to edit_notification_path(item), data: {turbo_frame: "modal"}, class: "text-gray-500 hover:text-gray-700" do %>
                     <i class="fas fa-clock text-3xl"></i>
                   <% end %>
                   <%= link_to edit_item_path(item), class: "text-gray-500 hover:text-gray-700" do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -17,9 +17,8 @@
               <div class="flex justify-center items-center my-2">
                 <p class="text-lg">商品名 : <%= item.name %></p>
               </div>
-              <div class="flex flex-auto justify-center items-center mt-1">
-                <p class="text-3xl">次回の通知日 : </p>
-                <p id="notification_#{@notification.id}" class="text-3xl font-bold text-red-600"><%= item.notification.next_notification_day %></p>
+              <div id="notification_<%= item.notification.id %>">
+                <%= render "notifications/modal", notification: item.notification %>
               </div>
               <div class="absolute top-2 right-2 flex space-x-2">
                 <div class="flex justify-end space-x-6">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,7 +3,7 @@
         <div class="p-4">
             <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">登録内容</div>
             <div class="flex justify-end space-x-6">
-                <%= link_to edit_notification_path(@item), class: "text-gray-500 hover:text-gray-700" do %>
+                <%= link_to edit_notification_path(@item), data: {turbo_frame: "modal"}, class: "text-gray-500 hover:text-gray-700" do %>
                     <i class="fas fa-clock text-3xl"></i>
                 <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -70,7 +70,7 @@
                 <div class="mb-4">
                     <div class="bg-gray-100 p-4 rounded ">
                     <label class="block text-gray-700 font-bold text-lg">通知予定日</label>
-                        <div class="text-2xl font-semibold text-green-800 p-4 rounded">
+                    <div id=<%= "notification_#{@notification.id}" %> class="text-2xl font-semibold text-green-800 p-4 rounded">
                             <%= @notification.next_notification_day %>
                         </div>
                     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <div class="pt-16">
+      <%= turbo_frame_tag "modal" %>
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>

--- a/app/views/notifications/_modal.html.erb
+++ b/app/views/notifications/_modal.html.erb
@@ -1,4 +1,7 @@
-<div class="flex flex-auto justify-center items-center mt-1">
-    <p class="text-3xl">次回の通知日 : </p>
-    <p id=<%= "notification_#{notification.id}" %> class="text-3xl font-bold text-red-600"><%= notification.next_notification_day %></p>
-</div>
+<turbo-frame id="modal">
+    <div data-controller="modal" data-action="turbo:submit-end->modal#hideOnSubmit">
+        <div class="flex flex-auto justify-center items-center mt-1">
+            <p id=<%= "notification_#{notification.id}" %> class="text-3xl font-bold text-red-600"><%= notification.next_notification_day %></p>
+        </div>
+    </div>
+</turbo-frame>

--- a/app/views/notifications/_modal.html.erb
+++ b/app/views/notifications/_modal.html.erb
@@ -1,26 +1,4 @@
-<turbo-frame id="modal">
-    <div data-controller="modal" data-action="turbo:submit-end->modal#hideOnSubmit keydown.esc->modal#hide" role="dialog" tabindex="-1" class="fixed inset-0 z-30 flex items-center justify-center w-full h-screen p-2">
-    <%= button_to nil, nil, type: :button, method: :get, form: { data: { action: "modal#hide" } }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
-        <div class="relative z-20 w-full max-w-2xl max-h-screen overflow-y-auto bg-white shadow-lg rounded-md">
-            <div class="py-8 flex items-center justify-center">
-                <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">
-                    <div class="text-center mb-6">
-                        <h2 class="text-2xl font-bold">次回通知日</h2>
-                    </div>
-                    <%= form_with model: @notification, local: true do |form| %>
-                        <div class="space-y-4">
-                            <%= render "shared/error_messages", object: @notification %>
-                            <div>
-                                <%= form.label :next_notification_day, "日付を選択", class: "block text-lg font-medium mb-2" %>
-                                <%= form.date_field :next_notification_day, class: "w-full p-3 border rounded-lg" %>
-                            </div>
-                            <div class="text-center">
-                                <%= form.submit "更新", class: "bg-green-800 hover:bg-green-700 text-white font-medium py-3 px-12 rounded text-center" %>
-                            </div>
-                        </div>
-                    <% end %>
-                </div>
-            </div>
-        </div>
-    </div>
-</turbo-frame>
+<div class="flex flex-auto justify-center items-center mt-1">
+    <p class="text-3xl">次回の通知日 : </p>
+    <p id=<%= "notification_#{notification.id}" %> class="text-3xl font-bold text-red-600"><%= notification.next_notification_day %></p>
+</div>

--- a/app/views/notifications/_modal.html.erb
+++ b/app/views/notifications/_modal.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="modal">
     <div data-controller="modal" data-action="turbo:submit-end->modal#hideOnSubmit">
-        <div class="flex flex-auto justify-center items-center mt-1">
-            <p id=<%= "notification_#{notification.id}" %> class="text-3xl font-bold text-red-600"><%= notification.next_notification_day %></p>
+        <div>
+            <p id=<%= "notification_#{notification.id}" %>><%= notification.next_notification_day %></p>
         </div>
     </div>
 </turbo-frame>

--- a/app/views/notifications/_modal.html.erb
+++ b/app/views/notifications/_modal.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="modal">
     <div data-controller="modal" data-action="turbo:submit-end->modal#hideOnSubmit keydown.esc->modal#hide" role="dialog" tabindex="-1" class="fixed inset-0 z-30 flex items-center justify-center w-full h-screen p-2">
-    <%= button_to nil, nil, type: :button, method: :get, form: { data: {action: "modal#hide"} }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
+    <%= button_to nil, nil, type: :button, method: :get, form: { data: { action: "modal#hide" } }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
         <div class="relative z-20 w-full max-w-2xl max-h-screen overflow-y-auto bg-white shadow-lg rounded-md">
             <div class="py-8 flex items-center justify-center">
                 <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">

--- a/app/views/notifications/edit.html.erb
+++ b/app/views/notifications/edit.html.erb
@@ -1,19 +1,26 @@
-<div class="bg-green-100 py-8 flex items-center justify-center">
-    <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">
-        <div class="text-center mb-6">
-            <h2 class="text-2xl font-bold">次回通知日</h2>
-        </div>
-        <%= form_with model: @notification, local: true do |form| %>
-            <div class="space-y-4">
-                <%= render "shared/error_messages", object: @notification %>
-                <div>
-                    <%= form.label :next_notification_day, "日付を選択", class: "block text-lg font-medium mb-2" %>
-                    <%= form.date_field :next_notification_day, class: "w-full p-3 border rounded-lg" %>
-                </div>
-                <div class="text-center">
-                    <%= form.submit "更新", class: "bg-green-800 hover:bg-green-700 text-white font-medium py-3 px-12 rounded text-center" %>
+<turbo-frame id="modal">
+    <div data-controller="modal" data-action="turbo:submit-end->modal#hideOnSubmit keydown.esc->modal#hide" role="dialog" tabindex="-1" class="fixed inset-0 z-30 flex items-center justify-center w-full h-screen p-2">
+        <%= button_to nil, nil, type: :button, method: :get, form: { data: {action: "modal#hide"} }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
+        <div class="relative z-20 w-full max-w-2xl max-h-screen overflow-y-auto bg-white shadow-lg rounded-md">
+            <div class="py-8 flex items-center justify-center">
+                <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">
+                    <div class="text-center mb-6">
+                        <h2 class="text-2xl font-bold">次回通知日</h2>
+                    </div>
+                    <%= form_with model: @notification, local: true do |form| %>
+                        <div class="space-y-4">
+                            <%= render "shared/error_messages", object: @notification %>
+                            <div>
+                                <%= form.label :next_notification_day, "日付を選択", class: "block text-lg font-medium mb-2" %>
+                                <%= form.date_field :next_notification_day, class: "w-full p-3 border rounded-lg" %>
+                            </div>
+                            <div class="text-center">
+                                <%= form.submit "更新", class: "bg-green-800 hover:bg-green-700 text-white font-medium py-3 px-12 rounded text-center" %>
+                            </div>
+                        </div>
+                    <% end %>
                 </div>
             </div>
-        <% end %>
+        </div>
     </div>
-</div>
+</turbo-frame>

--- a/app/views/notifications/edit.html.erb
+++ b/app/views/notifications/edit.html.erb
@@ -1,6 +1,6 @@
 <turbo-frame id="modal">
     <div data-controller="modal" data-action="turbo:submit-end->modal#hideOnSubmit keydown.esc->modal#hide" role="dialog" tabindex="-1" class="fixed inset-0 z-30 flex items-center justify-center w-full h-screen p-2">
-    <%= button_to nil, nil, type: :button, method: :get, form: { data: {action: "modal#hide"} }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
+    <%= button_to nil, nil, type: :button, method: :get, form: { data: { action: "modal#hide"} }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
         <div class="relative z-20 w-full max-w-2xl max-h-screen overflow-y-auto bg-white shadow-lg rounded-md">
             <div class="py-8 flex items-center justify-center">
                 <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">

--- a/app/views/notifications/edit.html.erb
+++ b/app/views/notifications/edit.html.erb
@@ -7,7 +7,7 @@
                     <div class="text-center mb-6">
                         <h2 class="text-2xl font-bold">次回通知日</h2>
                     </div>
-                    <%= form_with model: @notification, local: true do |form| %>
+                    <%= form_with model: @notification, data: { turbo_frame: "modal" } do |form| %>
                         <div class="space-y-4">
                             <%= render "shared/error_messages", object: @notification %>
                             <div>

--- a/app/views/notifications/update.turbo_stream.erb
+++ b/app/views/notifications/update.turbo_stream.erb
@@ -1,12 +1,6 @@
-<% if @notification.errors.present? %>
-  <%= turbo_stream.replace "modal" do %>
-    <%= render partial: "notifications/modal", locals: { notification: @notification } %>
-  <% end %>
-<% else %>
-  <%= turbo_stream.update "notification-#{@notification.id}" do %>
-    <%= @notification.next_notification_day %>
-  <% end %>
-  <%= turbo_stream.update "modal" do %>
-    <%= render partial: "notifications/modal", locals: { notification: @notification } %>
-  <% end %>
+<%= turbo_stream.update "notification-#{@notification.id}" do %>
+    <%= item.notification.next_notification_day %>
+    <%= turbo_stream.update "modal" do %>
+        <%= render partial: "notifications/modal", locals: { notification: @notification } %>
+    <% end %>
 <% end %>

--- a/app/views/notifications/update.turbo_stream.erb
+++ b/app/views/notifications/update.turbo_stream.erb
@@ -1,0 +1,11 @@
+<turbo-stream action="update" target="modal">
+    <template>
+        <%= render partial: "notifications/modal", locals: { notification: @notification } %>
+    </template>
+</turbo-stream>
+
+<turbo-stream action="update" target="notification-info">
+    <template>
+        <%= @notification.next_notification_day %>
+    </template>
+</turbo-stream>

--- a/app/views/notifications/update.turbo_stream.erb
+++ b/app/views/notifications/update.turbo_stream.erb
@@ -1,11 +1,12 @@
-<turbo-stream action="update" target="modal">
-    <template>
-        <%= render partial: "notifications/modal", locals: { notification: @notification } %>
-    </template>
-</turbo-stream>
-
-<turbo-stream action="update" target="notification-#{@notification.id}">
-    <template>
-        <%= @notification.next_notification_day %>
-    </template>
-</turbo-stream>
+<% if @notification.errors.present? %>
+  <%= turbo_stream.replace "modal" do %>
+    <%= render partial: "notifications/modal", locals: { notification: @notification } %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.update "notification-#{@notification.id}" do %>
+    <%= @notification.next_notification_day %>
+  <% end %>
+  <%= turbo_stream.update "modal" do %>
+    <%= render partial: "notifications/modal", locals: { notification: @notification } %>
+  <% end %>
+<% end %>

--- a/app/views/notifications/update.turbo_stream.erb
+++ b/app/views/notifications/update.turbo_stream.erb
@@ -4,7 +4,7 @@
     </template>
 </turbo-stream>
 
-<turbo-stream action="update" target="notification-info">
+<turbo-stream action="update" target="notification-#{@notification.id}">
     <template>
         <%= @notification.next_notification_day %>
     </template>


### PR DESCRIPTION
以下の変更を行いました。

## 変更前
- 通知予定日の編集ボタンを押すとnotifications/edit/idに遷移していた。

## 変更後
- 編集ボタンを押すとモーダルが現れるように変更し、変更結果がブラウザ上にAjaxで反映される。

## 用いた技術
Hotwire stimulus

## 参考記事
https://techracho.bpsinc.jp/hachi8833/2024_09_12/143416
https://qiita.com/mochimochifarao/items/9c5cd27f554d462f4d2e
https://qiita.com/jinta_02/items/7a4e14ba5973823551ad

- close #84 