### PR TITLE
カテゴリその他を選択した際の設定を調整

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,8 +25,8 @@ class ItemsController < ApplicationController
         @item.create_notification(
           next_notification_day: next_notification_day,
           notification_interval: notification_interval
-        )
-        redirect_to items_path, notice: "新たに日用品を登録しました"
+          )
+          redirect_to items_path, notice: "新たに日用品を登録しました"
       else
         render :new, status: :unprocessable_entity # エラーメッセージ表示
       end
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
   def update
     if @item.update(item_params)
       @item.notification.item_update_next_notification_day
-        redirect_to item_path(@item), notice: "登録内容を更新しました"
+        redirect_to items_path, notice: "登録内容を更新しました"
     else
       render :edit, status: :unprocessable_entity # エラーメッセージ表示
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -26,21 +26,26 @@ class Item < ApplicationRecord
     }
 
     def calculate_next_notification_day
-        # 一回の平均使用量
-        average_usage = AVERAGE_USAGE[self.category] || 0
-        # 一日の使用量
-        daily_usage = average_usage * self.used_count_per_day
+        if self.category == "others"
+            Date.today + 14.days
+        else
+            # 一回の平均使用量
+            average_usage = AVERAGE_USAGE[self.category] || 0
+            # 一日の使用量
+            daily_usage = average_usage * self.used_count_per_day
 
-        days = 0
-        while true
-            reminding_volume = self.volume - (daily_usage * days)
-            if reminding_volume <= (self.volume * 1.0 / 3)
-                break
-            else
-                days += 1
+            days = 0
+            max_days = 365
+            while days < max_days
+                reminding_volume = self.volume - (daily_usage * days)
+                if reminding_volume <= (self.volume * 1.0 / 3)
+                    break
+                else
+                    days += 1
+                end
             end
+            Date.today + days
         end
-        Date.today + days
     end
 
     def calculate_interval(next_notification_day)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,7 +43,7 @@ class Notification < ApplicationRecord
   def valid_update_next_notification_day
     if next_notification_day.blank?
       errors.add(:next_notification_day, :blank_field)
-    elsif next_notification_day < Date.today # + 1.days
+    elsif next_notification_day < Date.today + 1.days
       errors.add(:next_notification_day, :past_date)
     elsif next_notification_day > Date.today + 365.days
       errors.add(:next_notification_day, :too_far)

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -13,7 +13,7 @@
                     ['ボディソープ', 'body_soap'], 
                     ['洗濯用洗剤(粉)', 'laundry_detergent_powder'], 
                     ['洗濯用洗剤(液)', 'laundry_detergent_liquid'], 
-                    ['柔軟剤', 'fabric_softener'], 
+                    ['柔軟剤', 'fabric_softeners'], 
                     ['食器用洗剤', 'dishwashing_detergent'], 
                     ['化粧水', 'lotion'], 
                     ['美容液', 'serum'], 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -13,7 +13,7 @@
           ['ボディソープ', 'body_soap'], 
           ['洗濯用洗剤(粉)', 'laundry_detergent_powder'], 
           ['洗濯用洗剤(液)', 'laundry_detergent_liquid'], 
-          ['柔軟剤', 'fabric_softener'], 
+          ['柔軟剤', 'fabric_softeners'], 
           ['食器用洗剤', 'dishwashing_detergent'], 
           ['化粧水', 'lotion'], 
           ['美容液', 'serum'], 


### PR DESCRIPTION
- 登録・編集でカテゴリ”その他”を選択したとき、自動的に通知予定日が２週間後となるように設定しました。
