### PR TITLE
モーダルに通知間隔が表示されるように設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,8 +36,13 @@ class ItemsController < ApplicationController
   def edit; end
 
   def update
+    registered_volume = @item.volume
+    registered_used_count_per_day = @item.used_count_per_day
+
     if @item.update(item_params)
-      @item.notification.item_update_next_notification_day
+      if registered_volume != @item.volume || registered_used_count_per_day != @item.used_count_per_day
+        @item.notification.item_update_next_notification_day
+      end
         redirect_to items_path, notice: "登録内容を更新しました"
     else
       render :edit, status: :unprocessable_entity # エラーメッセージ表示

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,7 +5,10 @@ class Notification < ApplicationRecord
 
   # 通知日の更新
   def item_update_next_notification_day
-    self.update(next_notification_day: item.calculate_next_notification_day)
+    new_notification_day = item.calculate_next_notification_day
+    interval = (new_notification_day - Date.today).to_i
+    self.update(next_notification_day: item.calculate_next_notification_day,
+                notification_interval: interval)
   end
 
   def self.save_last_notification_day(notification)
@@ -14,7 +17,8 @@ class Notification < ApplicationRecord
 
   def notification_update_next_notification_day(new_notification_day)
     interval = (new_notification_day - Date.today).to_i
-    self.update(next_notification_day: new_notification_day, notification_interval: interval)
+    self.update(next_notification_day: new_notification_day,
+                notification_interval: interval)
   end
 
   def self.send_notifications
@@ -32,7 +36,8 @@ class Notification < ApplicationRecord
           Rails.logger.error("LINE通知送信エラー: #{error.message}")
         end
       else
-        Rails.logger.error("LINE通知送信エラー: UIDが見つかりません (Notification ID: #{notification.id})")
+        Rails.logger.error("LINE通知送信エラー: UIDが見つかりません 
+                          (Notification ID: #{notification.id})")
       end
     end
   end

--- a/app/views/notifications/edit.html.erb
+++ b/app/views/notifications/edit.html.erb
@@ -7,11 +7,16 @@
                     <div class="text-center mb-6">
                         <h2 class="text-2xl font-bold">次回通知日</h2>
                     </div>
+                    <div class="flex flex-auto justify-center items-center block text-lg font-medium gap-2">
+                        <p>前回の登録からの通知日間隔は</p>
+                        <p class="font-bold text-red-600"> <%= @notification.notification_interval %></p> 
+                        <p> 日です</p>
+                    </div>
                     <%= form_with model: @notification, data: { turbo_frame: "modal" } do |form| %>
                         <div class="space-y-4">
                             <%= render "shared/error_messages", object: @notification %>
                             <div>
-                                <%= form.label :next_notification_day, "日付を選択", class: "block text-lg font-medium mb-2" %>
+                                <%= form.label :next_notification_day, "日付を選択", class: "block flex justify-center text-lg font-medium mb-2" %>
                                 <%= form.date_field :next_notification_day, class: "w-full p-3 border rounded-lg" %>
                             </div>
                             <div class="text-center">


### PR DESCRIPTION
- モーダル上に、notification_intervalが表示されるように設定しました。
- Itemsコントローラーのupdateメソッドは、items/:id/editで更新ボタンを押すと実行されます。現在の状況だと、内包量と使用回数の変更がなくても計算をしてしまうため、上記のnotification_intervalやnext_notification_dayの値も再計算されます。notifications_コントローラーでupdateをしていた場合、せっかく調整した日付が上書きされてしまう状況でした。
なので今回、内包量と使用回数のどちらも変更がなかった場合は再計算されないように変更しました。