### PR TITLE
ボディのレスポンシブデザインを調整

### DIFF
--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="py-8 flex items-center justify-center">
-    <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">
+    <div class="rounded-lg w-full h-full max-w-xl p-8 bg-base-100 shadow-lg">
         <div class="p-4">
             <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">編集</div>
             <div data-controller="items">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,29 +1,61 @@
 <div class="py-8">
-  <div class="m-8 p-8 bg-base-100 shadow-lg ">
-  <%= render 'shared/flash_message' %>
-    <div class="p-4 font-bold">
+  <div class="m-8 p-8 bg-base-100 shadow-lg max-w-4xl mx-auto px-4">
+      <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-8">登録一覧</div>
+    <%= render 'shared/flash_message' %>
+    <div class="font-bold text-xl">
       <%= link_to '新規作成', new_item_path, class: 'text-blue-500 hover:underline' %>はこちら
       <% if @items.present? %>
-      <ul class="space-y-5">
-        <% @items.each do |item| %>
-          <div class="flex bg-base-300 shadow-lg rounded-lg flex justify-center items-center">
-            <a href="<%= item_path(item) %>", class="flex-shrink-0 hidden md:block hover:shadow-xl transition-shadow">
-              <img class="rounded-lg w-56 border-4 border-base-300" src="https://picsum.photos/300/180" alt="<%= item.name %>">
-            </a>
-            <div class="ml-6 flex-grow relative flex flex-col justify-center items-center h-32">
-              <div class="mb-1">
-                <p class="text-2xl">カテゴリー : <%= t("categories.#{item.category}") %></p>
+      <ul class="space-y-5 mt-4">
+      <% @items.each do |item| %>
+        <div class="block md:hidden">
+          <div class="mx-auto rounded-lg shadow-lg border overflow-hidden bg-base-200">
+            <div class="relative pb-[60%]">
+              <a href="<%= item_path(item) %>" class="flex-shrink-0 hover:shadow-2xl transition-shadow">
+                <img src="https://picsum.photos/300/180" class="absolute object-cover h-full w-full rounded-lg border-4" alt="<%= item.name %>">
+              </a>
+            </div>
+            <div class="p-4 space-y-3">
+              <p class="text-xl">カテゴリー : <%= t("categories.#{item.category}") %></p>
+              <p class="text-lg">商品名 : <%= item.name %></p>
+              <div class="flex items-baseline gap-3">
+                <p class="text-xl">次回の通知日</p>
+                <p id=<%= "notification_#{item.notification.id}" %> class="text-3xl font-bold text-red-600">
+                  <%= item.notification.next_notification_day %>
+                </p>
               </div>
+              <div class="flex justify-end space-x-4 mt-3">
+                <%= link_to edit_notification_path(item), data: {turbo_frame: "modal"}, class: "text-gray-500 hover:text-gray-700" do %>
+                  <i class="fas fa-clock text-2xl"></i>
+                <% end %>
+                <%= link_to edit_item_path(item), class: "text-gray-500 hover:text-gray-700" do %>
+                  <i class="fas fa-pen text-2xl"></i>
+                <% end %>
+                <%= link_to item_path(item), method: :delete, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "text-gray-500 hover:text-gray-700" do %>
+                  <i class="fas fa-trash text-2xl"></i>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
 
+        <div class="hidden md:block">
+          <div class="flex bg-base-200 shadow-lg rounded-lg w-4xl">
+            <a href="<%= item_path(item) %>" class="flex-shrink-0 hover:shadow-2xl transition-shadow">
+              <img src="https://picsum.photos/300/180" class="rounded-lg w-60 border-4 border-base-200" alt="<%= item.name %>">
+            </a>
+            <div class="ml-6 flex-grow relative flex flex-col justify-start items-start py-4 h-32">
+              <div class="mb-1">
+                <p class="text-xl">カテゴリー : <%= t("categories.#{item.category}") %></p>
+              </div>
               <div class="my-2">
                 <p class="text-lg">商品名 : <%= item.name %></p>
               </div>
-
-              <div class="flex flex-auto mt-1">
-                <p class="text-3xl">次回の通知日 : </p>
-                <p id=<%= "notification_#{item.notification.id}" %> class="text-3xl font-bold text-red-600"><%= item.notification.next_notification_day %></p>
+              <div class="flex flex-auto mt-1 items-baseline gap-3">
+                <p class="text-xl">次回の通知日</p>
+                <p id=<%= "notification_#{item.notification.id}" %> class="text-3xl font-bold text-red-600">
+                  <%= item.notification.next_notification_day %>
+                </p>
               </div>
-
               <div class="absolute top-2 right-2">
                 <div class="space-x-5">
                   <%= link_to edit_notification_path(item), data: {turbo_frame: "modal"}, class: "text-gray-500 hover:text-gray-700" do %>
@@ -37,11 +69,11 @@
                   <% end %>
                 </div>
               </div>
-
             </div>
           </div>
-        <% end %>
-      </ul>
+        </div>
+      <% end %>
+    </ul>
       <% else %>
         <div class="mb-3 text-center text-3xl text-gray-500">登録がありません</div>
       <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,5 +1,5 @@
 <div class="py-8 flex  justify-center items-center">
-  <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">
+  <div class="rounded-lg w-full h-full max-w-xl p-8 bg-base-100 shadow-lg">
     <div class="p-4">
       <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">新規登録</div>
       <div data-controller="items">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -2,7 +2,7 @@
     <div class="rounded-lg p-8 bg-base-100 shadow-lg">
         <div class="p-4">
             <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">登録内容</div>
-            <div class="flex justify-end space-x-6">
+            <div class="flex justify-end space-x-6 p-4">
                 <%= link_to edit_notification_path(@item), data: {turbo_frame: "modal"}, class: "text-gray-500 hover:text-gray-700" do %>
                     <i class="fas fa-clock text-3xl"></i>
                 <% end %>
@@ -16,9 +16,9 @@
                 <% end %>
             </div>
 
-            <div class="grid grid-cols-2 gap-8 justify-center">
+            <div class="grid grid-cols-2 gap-8 justify-center rounded-lg">
                 <div class="mb-4">
-                    <div class="bg-gray-100 p-4 rounded ">
+                    <div class="bg-gray-100 p-4 rounded">
                     <label class="block text-gray-700 font-bold mb-2 text-lg">カテゴリー</label>
                         <div class="text-2xl font-semibold text-green-800 p-4 rounded">
                             <%= t("categories.#{@item.category}") %>
@@ -27,16 +27,16 @@
                 </div>
 
                 <div class="mb-4">
-                    <div class="bg-gray-100 p-4 rounded ">
+                    <div class="bg-gray-100 p-4 rounded">
                     <label class="block text-gray-700 font-bold mb-2 text-lg">商品名</label>
-                        <div class="text-2xl font-semibold text-green-800 p-4 rounded dynamic-width">
+                        <div class="text-2xl font-semibold text-green-800 p-4 rounded">
                             <%= @item.name %>
                         </div>
                     </div>
                 </div>
 
                 <div class="mb-4">
-                    <div class="bg-gray-100 p-4 rounded ">
+                    <div class="bg-gray-100 p-4 rounded">
                     <label class="block text-gray-700 font-bold mb-2 text-lg">内包量</label>
                         <div class="text-2xl font-semibold text-green-800 p-4 rounded">
                             <%= @item.volume %>
@@ -46,7 +46,7 @@
                 </div>
 
                 <div class="mb-4">
-                    <div class="bg-gray-100 p-4 rounded ">
+                    <div class="bg-gray-100 p-4 rounded">
                     <label class="block text-gray-700 font-bold mb-2 text-lg">１日の使用回数</label>
                         <div class="text-2xl font-semibold text-green-800 p-4 rounded">
                             <%= @item.used_count_per_day %> 回 / 日
@@ -55,9 +55,9 @@
                 </div>
 
                 <div class="mb-4">
-                    <div class="bg-gray-100 p-4 rounded ">
-                    <label class="block text-gray-700 font-bold mb-8 text-lg">メモ内容</label>
-                        <div class="text-2xl font-semibold text-green-800 rounded">
+                    <div class="bg-gray-100 p-4 rounded">
+                    <label class="block text-gray-700 font-bold mb-2 text-lg">メモ内容</label>
+                        <div class="text-xl font-semibold text-green-800 p-4 rounded">
                             <% if @item.memo.present? %>
                                 <%= @item.memo %>
                             <% else %>
@@ -68,7 +68,7 @@
                 </div>
 
                 <div class="mb-4">
-                    <div class="bg-gray-100 p-4 rounded ">
+                    <div class="bg-gray-100 p-4 rounded">
                     <label class="block text-gray-700 font-bold text-lg">通知予定日</label>
                     <div id=<%= "notification_#{@notification.id}" %> class="text-2xl font-semibold text-green-800 p-4 rounded">
                             <%= @notification.next_notification_day %>

--- a/app/views/notifications/edit.html.erb
+++ b/app/views/notifications/edit.html.erb
@@ -3,7 +3,7 @@
     <%= button_to nil, nil, type: :button, method: :get, form: { data: { action: "modal#hide"} }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
         <div class="relative z-20 w-full max-w-2xl max-h-screen overflow-y-auto bg-white shadow-lg rounded-md">
             <div class="py-8 flex items-center justify-center">
-                <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-100 shadow-lg">
+                <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-200 shadow-xl">
                     <div class="text-center mb-6">
                         <h2 class="text-2xl font-bold">次回通知日</h2>
                     </div>


### PR DESCRIPTION
- 一覧、詳細、編集ページの画面サイズが変わると文字が潰れたりしてレイアウトが崩れていました。なのでレスポンシブデザインに対応するように調整し、一覧のカードデザインが変わるようにしました。
- close #83