### PR TITLE
ログイン前のヘッダーロゴのサイズを修正

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-base-300 fixed top-0 left-0 w-full z-50">
     <div class="flex-1">
-        <%= link_to 'Stock Mate', root_path, class: "btn btn-ghost text-5xl text-green-800 font-bold" %>
+        <%= link_to 'Stock Mate', root_path, class: "btn btn-ghost text-2xl text-green-800 font-bold" %>
     </div>
     <div>
         <%= button_to 'LINE登録で始める', user_line_omniauth_authorize_path, data: { turbo: false }, class: "bg-[#06C755] hover:bg-[#05b54c] text-white rounded px-4 py-2" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-base-300 fixed top-0 left-0 w-full z-50">
   <div class="flex-1">
-    <%= link_to 'Stock Mate', root_path, class: "btn btn-ghost  text-3xl md:text-5xl text-green-800 font-bold" %>
+    <%= link_to 'Stock Mate', root_path, class: "btn btn-ghost  text-2xl md:text-5xl text-green-800 font-bold" %>
   </div>
   <div class="flex space-x-2 md:space-x-3">
     <%= link_to "マイページ", items_path, class: "bg-green-800 hover:bg-green-700 text-white rounded px-2 md:px-4 py-2 text-sm md:text-white" %>


### PR DESCRIPTION
- ログイン前のヘッダー部分のStock Mateのリンクが右のボタンと重なってしまっていたので修正しました。