### PR TITLE
送信message本文を編集

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -53,9 +53,10 @@ class Item < ApplicationRecord
     end
 
     def create_notification_message
-        message = "#{self.name}の残量が少なくなっています\n"
-        message += " メモ: #{self.memo}\n" if self.memo.present?
-        message += "https://stockmate-a7c103b7b0ba.herokuapp.com/\n"
+        message = "#{self.name}の在庫補充をしてください\n"
+        message += "メモ書きがあります\n"
+        message += "メモ内容 : #{self.memo}\n" if self.memo.present?
+        message += "https://stockmate.dev/\n"
         message
     end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -48,7 +48,7 @@ class Notification < ApplicationRecord
   def valid_update_next_notification_day
     if next_notification_day.blank?
       errors.add(:next_notification_day, :blank_field)
-    elsif next_notification_day < Date.today + 1.days
+    elsif next_notification_day < Date.today# + 1.days
       errors.add(:next_notification_day, :past_date)
     elsif next_notification_day > Date.today + 365.days
       errors.add(:next_notification_day, :too_far)


### PR DESCRIPTION
- LINEに送信するメッセージの形式を変更しました。
- 講師の方にMVPを判定してもらうように仕様を一部変更しました。後で戻す予定です。
  - 通知予定日を当日に設定できるようにしました。
  - 通知判定を毎分10分ごとに行うようにしました。