### PR TITLE
deploy実行時にHeroku CLIをインストールするように設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
       - uses: akhileshns/heroku-deploy@v3.13.15
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
## 状況
先日のDocker 問題が発生した際の対処をしてから、Herokuへのデプロイがうまくいかない状態になっていました。

### エラーメッセージ
```
bin/sh: 1: heroku: not found
```

状況的にheroku CLIが見つからないということなので、deploy実行時にcliをインストールするように変更しました。