### PR TITLE
send_notificationの設定を修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,7 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [ :show, :edit, :update ]
 
   def index
-    @items = current_user.items.includes(:user).order(created_at: :desc)
+    @items = current_user.items.includes(:user, :notification).order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,4 +1,5 @@
 class LinebotController < ApplicationController
+    include Line::ClientConcern
     require "line/bot"
 
     skip_before_action :verify_authenticity_token
@@ -19,14 +20,5 @@ class LinebotController < ApplicationController
                 end
             end
         end
-    end
-
-    private
-
-    def client
-        @client ||= Line::Bot::Client.new { |config|
-        config.channel_secret = ENV["LINE_BOT_CHANNEL_SECRET"]
-        config.channel_token = ENV["LINE_BOT_CHANNEL_TOKEN"]
-        }
     end
 end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -21,13 +21,6 @@ class LinebotController < ApplicationController
         end
     end
 
-    def push_message(user_id, message)
-        client.push_message(user_id, {
-            type: "text",
-            text: message
-        })
-    end
-
     private
 
     def client

--- a/app/javascript/controllers/items_controller.js
+++ b/app/javascript/controllers/items_controller.js
@@ -3,6 +3,7 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   static targets = ["categorySelect", "unit", "select"];
 
+  // iconPathをマッピング
   iconMapping = {
     'shampoo': '/assets/icons/shampoo.jpg',
     'body_soap': '/assets/icons/body_soap.jpg',
@@ -18,6 +19,7 @@ export default class extends Controller {
     'others': '/assets/icons/others.jpg'
   }
 
+  // カテゴリー未選択の場合はエラー
   confirmIcon(event) {
     const selectedCategory = this.categorySelectTarget.value
     if (!selectedCategory) {
@@ -26,6 +28,7 @@ export default class extends Controller {
       return false
     }
 
+    // 入力されたデータからアセットパイプラインを利用して画像を選択して取得
     const hidden = document.createElement("input")
     const iconPath = this.iconMapping[selectedCategory] || this.iconMapping["others"]
     hiddenIconField.type = "hidden"
@@ -36,11 +39,13 @@ export default class extends Controller {
     return true
   }
 
+  // カテゴリー選択時に単位を変更
   connect() {
     this.updateUnit();
     this.categorySelectTarget.addEventListener('change', () => this.updateUnit());
   }
 
+  // switch文で選択したvalueを返す
   updateUnit() {
     let unit = "";
     const value = this.categorySelectTarget.value;

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -2,10 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["modal"]
 
+  // 接続時に要素にフォーカスを設定
   connect() {
     this.element.focus();
   }
 
+  // デフォルト動作を防止し、削除
   hide(event) {
     if (event) {
       event.preventDefault();
@@ -13,11 +15,14 @@ export default class extends Controller {
     this.element.remove();
   }
 
+  // フォーム送信したらモーダル非表示
   hideOnSubmit(event) {
     if (event && event.detail.success) {
       this.hide();
     }
   }
+
+  //切断時にturbo-flameのsrcをリセット
   disconnect() {
     if (this.element) {
       const frame = this.#modalTurboFrame;
@@ -27,6 +32,7 @@ export default class extends Controller {
     }
   }
 
+  // if="modal"のturbo-flame要素を取得
   get #modalTurboFrame() {
     return document.querySelector("turbo-frame[id='modal']");
   }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -49,10 +49,4 @@ class Item < ApplicationRecord
         (next_notification_day - Date.today).to_i
     end
 
-    def create_notification_message
-        message = "#{self.name}の在庫補充をしてください\n"
-        message += "メモ書きがあります。メモ内容 : #{self.memo}\n" if self.memo.present?
-        message += "https://stockmate.dev/\n"
-        message
-    end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,5 @@
 class Notification < ApplicationRecord
+  include Line::ClientConcern
   belongs_to :item
 
   validate :valid_update_next_notification_day
@@ -26,10 +27,6 @@ class Notification < ApplicationRecord
     if line_user_id.present?
       message = item.create_notification_message
       begin
-        client = Line::Bot::Client.new do |config|
-          config.channel_secret = ENV["LINE_BOT_CHANNEL_SECRET"]
-          config.channel_token = ENV["LINE_BOT_CHANNEL_TOKEN"]
-        end
         message = {
           type: "text",
           text: message

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container py-8 flex items-center justify-center">
-    <div class="rounded-lg w-full h-full max-w-xl p-8 bg-base-100 shadow-lg">
+    <div class="rounded-lg w-full h-full max-w-xl bg-[#f8fffb] p-8 shadow-lg">
         <div class="p-4">
             <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">編集</div>
             <div data-controller="items category-icon">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,5 +1,5 @@
 <div class="py-8">
-  <div class="container m-8 p-8 bg-base-100 shadow-lg max-w-4xl mx-auto px-4">
+  <div class="container m-8 p-8 shadow-lg max-w-4xl mx-auto bg-[#f8fffb] px-4">
       <div class="font-bold mt-8 text-center text-8xl text-green-800 mb-8">登録一覧</div>
     <%= render 'shared/flash_message' %>
     <div class="font-bold text-xl">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container py-8 flex  justify-center items-center">
-  <div class="rounded-lg w-full h-full max-w-xl p-8 bg-base-100 shadow-lg">
+  <div class="rounded-lg w-full h-full max-w-xl p-8 bg-[#f8fffb] shadow-lg">
     <div class="p-4">
       <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">新規登録</div>
       <div data-controller="items category-icon">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,5 +1,5 @@
 <div class="py-8">
-    <div class="container rounded-lg bg-base-100 shadow-lg max-w-4xl mx-auto px-4">
+    <div class="container rounded-lg shadow-lg max-w-4xl mx-auto bg-[#f8fffb] px-4">
         <div class="p-2 md:p-4">
             <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">登録内容</div>
             <div class="flex justify-end space-x-6 p-4">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    # application.jsファイルをHTMLに読み込むためのタグ
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-    # icon awesome kit
     <script src="https://kit.fontawesome.com/67993d43f3.js" crossorigin="anonymous"></script>
   </head>
 

--- a/app/views/notifications/edit.html.erb
+++ b/app/views/notifications/edit.html.erb
@@ -3,7 +3,7 @@
     <%= button_to nil, nil, type: :button, method: :get, form: { data: { action: "modal#hide"} }, class: "fixed inset-0 block w-full h-screen cursor-default bg-gray-900/30" %>
         <div class="container relative z-20 w-full max-w-2xl max-h-screen overflow-y-auto bg-white shadow-lg rounded-md">
             <div class="py-8 flex items-center justify-center">
-                <div class="rounded-lg w-full h-full max-w-md p-8 bg-base-200 shadow-xl">
+                <div class="rounded-lg w-full h-full max-w-md p-8 bg-gray-100 shadow-xl">
                     <div class="text-center mb-6">
                         <h2 class="text-2xl font-bold">次回通知日</h2>
                     </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,7 +1,7 @@
-<div class="navbar bg-base-100 fixed top-0 left-0 w-full z-50">
+<div class="navbar bg-[#f8fffb] fixed top-0 left-0 w-full z-50">
     <div class="flex-1">
         <%= link_to root_path, class: "btn btn-ghost" do %>
-            <%= image_tag("stockmate_logo.png", class: "h-10 md:h-14", alt: "Stock Mate") %>
+            <%= image_tag("stockmate_logo.png", class: "h-8 md:h-12", alt: "Stock Mate") %>
         <% end %>
     </div>
     <div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
-<div class="navbar bg-base-100 fixed top-0 left-0 w-full z-50">
+<div class="navbar fixed top-0 left-0 w-full bg-[#f8fffb] z-50">
   <div class="flex-1">
     <%= link_to root_path, class: "btn btn-ghost" do %>
-      <%= image_tag("stockmate_logo.png", class: "h-10 md:h-12", alt: "Stock Mate") %>
+      <%= image_tag("stockmate_logo.png", class: "h-8 md:h-12", alt: "Stock Mate") %>
     <% end %>
   </div>
   <div class="flex space-x-2 md:space-x-3">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,5 +1,5 @@
 <div class="py-8">
-    <div class="container m-8 p-8 shadow-lg max-w-4xl mx-auto text-center px-4">
+    <div class="container m-8 p-8 shadow-lg max-w-4xl bg-[#f8fffb] mx-auto text-center px-4">
         <div class="text-8xl font-bold text-green-800 underline py-5">
             Stock Mate
         </div>

--- a/lib/line/client_concern.rb
+++ b/lib/line/client_concern.rb
@@ -1,0 +1,10 @@
+module Line
+    module ClientConcern
+        def client
+        @client ||= Line::Bot::Client.new do |config| {
+            config.channel_secret = ENV["LINE_BOT_CHANNEL_SECRET"]
+            config.channel_token = ENV["LINE_BOT_CHANNEL_TOKEN"]
+        }
+        end
+    end
+end


### PR DESCRIPTION
## 現状
現在の設定は登録内容を確認し、メッセージをLINE に送信するようになっています。ただ、現在はメッセージの作成はitemモデルに、通知ユーザーを探すロジックはnotificationモデル、送信はlinenotコントローラーと、あちこちに散らばっています。
この状態だとどこを修正すればいいか管理が大変なので、一箇所にまとめたい。

## 修正
linebotコントローラーとitemモデルの記述をnotificationモデルに集約しました。
また、clientメソッドがnotificationモデルでも必要になったので、lib/line/配下にclient_concern.rbを作成しました。
