### PR TITLE
lineを送信できない不具合を修正

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -25,7 +25,7 @@ class Notification < ApplicationRecord
     user = item&.user
     line_user_id = user&.uid
     if line_user_id.present?
-      message = item.create_notification_message
+      message = self.create_notification_message
       begin
         message = {
           type: "text",


### PR DESCRIPTION
## 現状
ターミナル上でrails runner を実行して送信テストを行ったところ、エラーが発生したためこれを修正しました。

## 原因
メッセージ作成と通知機能をnotificationモデルに集約させた際、移動させたitemモデルのインスタンスメソッドをそのまま呼び出そうとしてしまったためにエラーを起こしていた。

## 修正
notificationに定義しなおしていたので、同じインスタンス内のメソッドを呼び出すように修正しました。
