### PR TITLE
08 linebot

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -5,20 +5,71 @@ class LinebotController < ApplicationController
     skip_before_action :verify_authenticity_token
 
     def callback
-        body = request.body.read
-        events = client.parse_events_from(body)
+
+        signature = request.env['HTTP_X_LINE_SIGNATURE']
+
+        unless client.validate_signature(request_body, signature)
+            head :bad_request
+            return
+        end
+
+        events = client.parse_events_from(request_body)
         events.each do |event|
-            case event
-            when Line::Bot::Event::Message
-                case event.type
-                when Line::Bot::Event::MessageType::Text
-                    message = {
-                        type: "text",
-                        text: event.message["text"]
-                    }
-                    client.reply_message(event["replyToken"], message)
-                end
+            client.reply_message(event["replyToken"], message(event))
+        end
+    end
+
+    private
+
+    def request_body
+        request.body.read
+    end
+
+    def message(event)
+        case event
+        when Line::Bot::Event::Message
+            case event.type
+            when Line::Bot::Event::MessageType::Text
+                handle_message_event(event)
             end
         end
+    end
+
+    def handle_message_event(event)
+        user_id = event["source"]["userId"]
+        case event.message["text"]
+        when "登録確認"
+            {
+                type: "text",
+                text: get_inventory_list
+            }
+        end
+    end
+
+    def get_inventory_list
+        items = Item.includes(:notification).all
+        if items.present?
+            format_items_message(items)
+        else
+            "登録されている日用品はありません。"
+        end
+    end
+
+    def format_items_message(items)
+        items.map do |item|
+            item_lists = [
+                "商品名: 【#{item.name}】",
+                "カテゴリー: #{I18n.t("categories.#{item.category}", default: item.category)}",
+                "次回通知日: #{item.notification.next_notification_day}",
+            ]
+
+            if item.memo.present?
+                item_lists << "メモ内容: #{item.memo}"
+            end
+
+            item_lists << "-----------------"
+            item_lists.join("\n")
+
+        end.join("\n")
     end
 end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -5,8 +5,7 @@ class LinebotController < ApplicationController
     skip_before_action :verify_authenticity_token
 
     def callback
-
-        signature = request.env['HTTP_X_LINE_SIGNATURE']
+        signature = request.env["HTTP_X_LINE_SIGNATURE"]
 
         unless client.validate_signature(request_body, signature)
             head :bad_request
@@ -60,7 +59,7 @@ class LinebotController < ApplicationController
             item_lists = [
                 "商品名: 【#{item.name}】",
                 "カテゴリー: #{I18n.t("categories.#{item.category}", default: item.category)}",
-                "次回通知日: #{item.notification.next_notification_day}",
+                "次回通知日: #{item.notification.next_notification_day}"
             ]
 
             if item.memo.present?
@@ -69,7 +68,6 @@ class LinebotController < ApplicationController
 
             item_lists << "-----------------"
             item_lists.join("\n")
-
         end.join("\n")
     end
 end


### PR DESCRIPTION
以下の内容を実装しました。

## 実装
- LINE画面にリッチメニューを作成し、表示しました。
  - 登録確認・在庫補充をタップすると、「登録確認」「在庫補充」と入力されます。
  - 右のアイコンをタップするとアプリにアクセスします。

- linebotコントローラーを編集し、「登録確認」と入力されると現在、登録されているすべての日用品の以下の項目を送信します。
  - 商品名
  - カテゴリー名
  - 次回通知日
  - メモ（登録がある場合）

## 所感
以下の２点で手こずった。
- 最初LINEのwebhookURLが500エラーを叩いた。原因はitem.memoがnilとなるにも関わらず配列に入れようとする設定にしてしまっていたから。なのでもしmemoが存在する場合のみ配列に追加するように設定を変更した。
- 次回通知日がうまく取得できていなかった。原因はget_inventory_listメソッドでItem.allで取得する際にN＋1問題が発生して何らかの不具合が発生していた。includes(:notification)をつけたら解決した。



