### PR TITLE
他のユーザーの登録が確認できないように調整

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,10 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [ :show, :edit, :update ]
 
   def index
-    @items = current_user.items.includes(:user, :notification).order(created_at: :desc)
+    @items = current_user.items
+                        .joins(:notification)
+                        .includes(:user, :notification)
+                        .order("notifications.next_notification_day ASC")
   end
 
   def show

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -40,13 +40,22 @@ class LinebotController < ApplicationController
         when "登録確認"
             {
                 type: "text",
-                text: get_inventory_list
+                text: get_inventory_list(event)
             }
         end
     end
 
-    def get_inventory_list
-        items = Item.includes(:notification).all
+    def get_inventory_list(event)
+        user = User.find_by(uid: event["source"]["userId"])
+
+        if user.nil?
+            return "まずはユーザー登録をお願いします！"
+        end
+
+        items = user.items.joins(:notification)
+                          .includes(:notification)
+                          .order("notifications.next_notification_day ASC")
+
         if items.present?
             format_items_message(items)
         else


### PR DESCRIPTION
以下の変更を行いました。

## 現状
- 現在、LINE上で「登録確認」と入力されると、すべての登録を検索して通知します。そのため他のユーザーの登録も通知してしまうため、ユーザーが登録したものだけを取得するように修正しました。
- 現在の登録一覧は、登録順に表示されます。これを次回通知日の近い順に並べ替えました。

## 原因
- get_inventory_listメソッドでuserに関する条件を設定していませんでした。

## 変更
- メソッド内でuserに関する定義付けを行い、以降の検索コードをItem.allからuser.items~と変更しました。
- テーブルをjoinし、並べ替えを行えるように調整しました。同様の変更をitemコントローラーにも導入しました。

## 所感
- ユーザーにMVPリリースする前に気づけてよかった。
- 本番環境での不具合はローカルだと気づけない場合があるから怖い。
