### PR TITLE
LINEBOT　在庫補充機能を実装

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,8 +1,9 @@
 class LinebotController < ApplicationController
     include Line::ClientConcern
     require "line/bot"
-
     skip_before_action :verify_authenticity_token
+
+    MESSAGE_STEP = {}
 
     def callback
         signature = request.env["HTTP_X_LINE_SIGNATURE"]
@@ -42,9 +43,60 @@ class LinebotController < ApplicationController
                 type: "text",
                 text: get_inventory_list(event)
             }
+        when "在庫補充"
+            MESSAGE_STEP[user_id] = true
+            message = {
+                type: "text",
+                text: "登録している【商品名】を入力してください。"
+            }
+        else
+            if MESSAGE_STEP[user_id] == true
+                result = handle_message_item_name(event)
+                MESSAGE_STEP[user_id] = false
+                result
+            else
+                message = {
+                    type: "text",
+                    text: "まずはメニューから操作を選択してください。"
+                }
+            end
         end
     end
 
+    # 在庫補充
+    def handle_message_item_name(event)
+        user = User.find_by(uid: event["source"]["userId"])
+
+        if user.nil?
+            return {
+                type: "text",
+                text: "まずはユーザー登録をお願いします！"
+            }
+        end
+
+        item_name = event.message["text"]
+        item = Item.find_by(name: item_name)
+
+        if item.nil?
+            return {
+                type: "text",
+                text: "#{item_name}は登録されていません。"
+            }
+        end
+
+        current_volume = item.current_volume
+        next_notification_day = item.calculate_next_notification_day(current_volume: current_volume)
+
+        if item.update(volume: current_volume)
+            item.notification.item_update_next_notification_day
+        end
+            {
+            type: "text",
+            text: "#{item.name}を補充しました。\n次回通知日は#{item.notification.next_notification_day}です。"
+        }
+    end
+
+    # 登録確認
     def get_inventory_list(event)
         user = User.find_by(uid: event["source"]["userId"])
 
@@ -63,6 +115,7 @@ class LinebotController < ApplicationController
         end
     end
 
+    # 登録一覧のメッセージ
     def format_items_message(items)
         items.map do |item|
             item_lists = [

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -75,22 +75,18 @@ class LinebotController < ApplicationController
         end
 
         item_name = event.message["text"]
-        item = Item.find_by(name: item_name)
-
+        item = Item.joins(:notification)
+                   .includes(:notification)
+                   .find_by(name: item_name)
         if item.nil?
             return {
                 type: "text",
-                text: "#{item_name}は登録されていません。"
+                text: "#{item_name}は登録されていません。\n登録一覧で確認をお願いします。"
             }
         end
 
-        current_volume = item.current_volume
-        next_notification_day = item.calculate_next_notification_day(current_volume: current_volume)
-
-        if item.update(volume: current_volume)
-            item.notification.item_update_next_notification_day
-        end
-            {
+        item.notification.line_update_next_notification_day
+        {
             type: "text",
             text: "#{item.name}を補充しました。\n次回通知日は#{item.notification.next_notification_day}です。"
         }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,28 +23,19 @@ class Item < ApplicationRecord
         "others" => 10
     }
 
-    def current_volume
-        return self.volume if self.category == "others"
-
-        notification_volume = self.volume / 3
-        days_passed = (Date.today - self.created_at.to_date).to_i
-        daily_usage = calculate_daily_usage
-        [self.volume - (days_passed * daily_usage), notification_volume].max        
-    end
-
-    def calculate_next_notification_day(current_volume: nil)
+    def calculate_next_notification_day
         if self.category == "others"
             return Date.today + 14.days
-        else
-            daily_usage = calculate_daily_usage
-            total_volume = current_volume.nil? ? self.volume : current_volume + self.volume
         end
+
+        daily_usage = calculate_daily_usage
+        notification_volume = ( self.volume * 1.0 / 3 ).ceil(2)
 
         days = 0
         max_days = 365
         while days < max_days
-            reminding_volume = total_volume - (daily_usage * days)
-            if reminding_volume <= (self.volume * 1.0 / 3)
+            reminding_volume = self.volume - (daily_usage * days)
+            if reminding_volume <= notification_volume
                 break
             else
                 days += 1
@@ -55,6 +46,28 @@ class Item < ApplicationRecord
 
     def calculate_interval(next_notification_day)
         (next_notification_day - Date.today).to_i
+    end
+
+    def line_calculate_next_notification_day
+        if self.category == "others"
+            return Date.today + 14.days
+        end
+
+        daily_usage = calculate_daily_usage
+        notification_volume = ( self.volume * 1.0 / 3 ).ceil(2)
+        total_volume = notification_volume + self.volume
+
+        days = 0
+        max_days = 365
+        while days < max_days
+            reminding_volume = total_volume - (daily_usage * days)
+            if reminding_volume <= notification_volume
+                break
+            else
+                days += 1
+            end
+        end
+        days
     end
 
     private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -29,7 +29,7 @@ class Item < ApplicationRecord
         notification_volume = self.volume / 3
         days_passed = (Date.today - self.created_at.to_date).to_i
         daily_usage = calculate_daily_usage
-        self.volume - (days_passed * daily_usage)
+        [self.volume - (days_passed * daily_usage), notification_volume].max        
     end
 
     def calculate_next_notification_day(current_volume: nil)
@@ -37,11 +37,7 @@ class Item < ApplicationRecord
             return Date.today + 14.days
         else
             daily_usage = calculate_daily_usage
-            if current_volume.nil?
-                total_volume = self.volume
-            else
-                total_volume = current_volume + self.volume
-            end
+            total_volume = current_volume.nil? ? self.volume : current_volume + self.volume
         end
 
         days = 0

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,7 +5,7 @@ class Notification < ApplicationRecord
   validate :valid_update_next_notification_day
 
   def item_update_next_notification_day
-    new_notification_day = item.calculate_next_notification_day
+    new_notification_day = item.calculate_next_notification_day(current_volume: item.current_volume)
     interval = (new_notification_day - Date.today).to_i
     self.update(next_notification_day: item.calculate_next_notification_day,
                 notification_interval: interval)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,9 +5,15 @@ class Notification < ApplicationRecord
   validate :valid_update_next_notification_day
 
   def item_update_next_notification_day
-    new_notification_day = item.calculate_next_notification_day(current_volume: item.current_volume)
+    new_notification_day = item.calculate_next_notification_day
     interval = (new_notification_day - Date.today).to_i
-    self.update(next_notification_day: item.calculate_next_notification_day,
+    self.update(next_notification_day: new_notification_day,
+                notification_interval: interval)
+  end
+
+  def notification_update_next_notification_day(new_notification_day)
+    interval = (new_notification_day - Date.today).to_i
+    self.update(next_notification_day: new_notification_day,
                 notification_interval: interval)
   end
 
@@ -15,10 +21,13 @@ class Notification < ApplicationRecord
     self.update(last_notification_day: Date.today)
   end
 
-  def notification_update_next_notification_day(new_notification_day)
-    interval = (new_notification_day - Date.today).to_i
-    self.update(next_notification_day: new_notification_day,
-                notification_interval: interval)
+  def line_update_next_notification_day
+    interval_days = item.line_calculate_next_notification_day
+    new_notification_day = Date.today + interval_days
+
+    self.update(
+      next_notification_day: new_notification_day,
+      notification_interval: interval_days)
   end
 
   def push_line_message


### PR DESCRIPTION
以下の内容を実装しました。

## 実装
- 通知の再設定機能
  - LINE上から在庫補充と入力し、日用品の商品名を続けて入力することで、一致するものの通知日を再設定します。

## 課題
- 同じカテゴリ、同じ商品名の登録がある場合、処理が片方のみなので、バリデーションでカテゴリ、商品名が同一のものは登録できないように設定するようにする。
- 通知がまだ来ていないものも再設定することができてしまう。再計算する際、すでに通知が来る残量の状態という過程なので、通知前に在庫補充をされてしまうと想定よりずれてしまう。対応としてenumなどの属性を持たせて、通知が済んでいるデータのみ操作を行えるような設定にする？また、これを利用してブラウザ上でも通知をON/OFFする機能を持たせることもできるか検討。

- close #138 


