### PR TITLE
カテゴリー「その他」のLINEBOTから在庫補充ができない不具合を修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -41,6 +41,7 @@ class Item < ApplicationRecord
                 days += 1
             end
         end
+        # 日付を返す
         Date.today + days
     end
 
@@ -50,7 +51,7 @@ class Item < ApplicationRecord
 
     def line_calculate_next_notification_day
         if self.category == "others"
-            return Date.today + 14.days
+            return 14
         end
 
         daily_usage = calculate_daily_usage
@@ -67,6 +68,7 @@ class Item < ApplicationRecord
                 days += 1
             end
         end
+        # 日数を返す
         days
     end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -24,7 +24,6 @@ class Notification < ApplicationRecord
   def line_update_next_notification_day
     interval_days = item.line_calculate_next_notification_day
     new_notification_day = Date.today + interval_days
-
     self.update(
       next_notification_day: new_notification_day,
       notification_interval: interval_days)


### PR DESCRIPTION
以下の不具合を修正しました。

## 現状
- LINEBOT上から在庫補充と入力し、その他カテゴリーの商品名を入力しても処理が行われず、次回通知日も更新されません。

## 原因
- 計算式の算出するデータの型の違いが原因でした。当初、line_calculate_next_notification_dayメソッドはカテゴリーがothersの場合Date.today + 14daysと、日付を返していました。しかし、この計算式は日数を返すためのメソッドのため、うまくデータを引き渡すことができていませんでした。

## 変更
- カテゴリーがothersのとき、数字の14を返すように変更しました。

## 所感
- メソッドで出力するデータの最終型を意識してコードを設計する。


