### PR TITLE
不要なページにURL直打ちでアクセスできないように設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ group :development, :test do
 
   gem "factory_bot_rails"
 
+  gem "faker"
+
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", "~> 7.0.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -411,6 +413,7 @@ DEPENDENCIES
   devise-i18n-views
   dotenv-rails
   factory_bot_rails
+  faker
   hotwire-rails
   jbuilder
   jsbundling-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+
+  def render_404
+    render file: "#{Rails.root}/public/404.html", status: :not_found
+  end
 end

--- a/app/javascript/controllers/items_controller.js
+++ b/app/javascript/controllers/items_controller.js
@@ -31,10 +31,10 @@ export default class extends Controller {
     // 入力されたデータからアセットパイプラインを利用して画像を選択して取得
     const hidden = document.createElement("input")
     const iconPath = this.iconMapping[selectedCategory] || this.iconMapping["others"]
-    hiddenIconField.type = "hidden"
-    hiddenIconField.name = "item[icon_path]"
-    hiddenIconField.value = iconPath
-    event.target.appendChild(hiddenIconField)
+    hidden.type = "hidden"
+    hidden.name = "item[icon_path]" //params[:item][:icon_path]と同義
+    hidden.value = iconPath
+    event.target.appendChild(hidden)
 
     return true
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,4 +42,3 @@ class User < ApplicationRecord
     self.save!
   end
 end
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,23 +7,39 @@ class User < ApplicationRecord
 
   has_many :items, dependent: :destroy
 
+  # LINEから取得した情報でユーザーを検索または作成
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create! do |user|
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0, 20] # ランダムパスワードを生成
+      user.name = auth.info.name
+    end
+  end
+
+  # LINEからのプロフィール情報を取得
   def social_profile(provider)
     social_profiles.select { |sp| sp.provider == provider.to_s }.first
   end
 
+  # LINE認証で取得した情報をユーザーモデルに設定
   def set_values(omniauth)
+    # プロバイダーとuidが一致する場合のみ処理を実行
     return if provider.to_s != omniauth["provider"].to_s || uid != omniauth["uid"]
     credentials = omniauth["credentials"]
     info = omniauth["info"]
 
+    # 保存する認証情報
     access_token = credentials["refresh_token"]
     access_secret = credentials["secret"]
     credentials = credentials.to_json
     name = info["name"]
   end
 
+  # LINE APIから取得したユーザー情報を保存
   def set_values_by_raw_info(raw_info)
+    # JSON形式で保存
     self.raw_info = raw_info.to_json
     self.save!
   end
 end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
+  devise :database_authenticatable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[line]
 
   has_many :items, dependent: :destroy

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="container py-8 flex items-center justify-center">
-    <div class="rounded-lg w-full h-full max-w-xl bg-[#f8fffb] p-8 shadow-lg">
+<div class="min-h-screen flex justify-center items-center">
+    <div class="container rounded-lg w-full max-w-xl mx-auto p-8 bg-[#f8fffb]/75 shadow-lg">
         <div class="p-4">
             <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">編集</div>
             <div data-controller="items category-icon">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,5 +1,5 @@
-<div class="container py-8 flex  justify-center items-center">
-  <div class="rounded-lg w-full h-full max-w-xl p-8 bg-[#f8fffb] shadow-lg">
+<div class="min-h-screen flex justify-center items-center">
+  <div class="container rounded-lg w-full max-w-xl mx-auto p-8 bg-[#f8fffb]/75 shadow-lg">
     <div class="p-4">
       <div class="font-bold mt-8 text-center text-5xl text-green-800 mb-6">新規登録</div>
       <div data-controller="items category-icon">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     omniauth_callbacks: "omniauth_callbacks"
-  }
+  },
+  # 不要なアクションをスキップ
+  skip: [ :registrations, :password, :sessions ]
 
   # ログアウトのルーティングをscopeで指定
   devise_scope :user do
@@ -26,4 +28,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  # 全てのビューファイルでの404エラーに対して対応
+  match "*path", to: "application#render_404", via: :all
 end

--- a/public/404.html
+++ b/public/404.html
@@ -32,7 +32,7 @@
   }
 
   .rails-default-error-page h1 {
-    font-size: 100%;
+    font-size: 300%;
     color: #730E15;
     line-height: 1.5em;
   }
@@ -58,10 +58,11 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>404.not_found</h1>
+      <p>お探しのページは見つかりませんでした。</p>
+      <br>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>「LINE登録で始める」から進んでいただくか、下部のお問い合わせフォームからお知らせください。</p>
   </div>
 </body>
 </html>

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+    factory :item do
+        category { "shampoo" }
+        name { "Test_item" }
+        volume { 300 }
+        used_count_per_weekly { 7 }
+        memo { "test" }
+    end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe User, type: :model do
         let(:auth) { OmniAuth.config.mock_auth[:line] }
 
         it 'ユーザー作成' do
-        # OmniAuthのモックデータを使って、ユーザーを作成
+            # OmniAuthのモックデータを使って、ユーザーを作成
             user = User.from_omniauth(auth)
 
-        # ユーザーが正しく作成されているか確認
+            # ユーザーが正しく作成されているか確認
             expect(user).to be_persisted
             expect(user.email).to eq('test@example.com')
             expect(user.name).to eq('Test User')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+    describe 'LINE認証データからユーザーを作成' do
+        before { mock_auth_hash }
+        let(:auth) { OmniAuth.config.mock_auth[:line] }
+
+        it 'ユーザー作成' do
+        # OmniAuthのモックデータを使って、ユーザーを作成
+            user = User.from_omniauth(auth)
+
+        # ユーザーが正しく作成されているか確認
+            expect(user).to be_persisted
+            expect(user.email).to eq('test@example.com')
+            expect(user.name).to eq('Test User')
+            expect(user.provider).to eq('line')
+            expect(user.uid).to eq('12345')
+        end
+    end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,9 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+# supportsディレクトリ配下の全てのファイルを読み取り
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -37,6 +40,11 @@ RSpec.configure do |config|
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
   ]
+
+  # FactoryBot
+  config.include FactoryBot::Syntax::Methods
+  # Omniauthマクロ読み込み
+  config.include LineloginMacros
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
@@ -68,3 +76,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+# OmniAuthのテストモードを有効化
+OmniAuth.config.test_mode = true

--- a/spec/support/linelogin_macros.rb
+++ b/spec/support/linelogin_macros.rb
@@ -1,0 +1,12 @@
+module LineloginMacros
+    def mock_auth_hash
+        OmniAuth.config.mock_auth[:line] = OmniAuth::AuthHash.new({
+            provider: 'line',
+            uid: '12345',
+            info: {
+                email: 'test@example.com',
+                name: 'Test User'
+            }
+        })
+    end
+end


### PR DESCRIPTION
以下の内容を変更しました。
## 現状
現在のアプリではLINE認証ログイン機能のみを使用しています。なのでdeviseでの通常のログイン機能やパスワードリセット機能は実装していないのですが、/users/sign_inなどとURLを直接入力すると入力ページに入れてしまいます。

## 達成したいこと
URLを入力した時、404を表示するようにする。

## 変更
コントローラーでNotFoundとRouting Errorが発生した際には404を呼び出すように設定。
ルーティングでは、deviseの特定のアクションに対してスキップし、全ビューファイルを対象にするように設定。

## 結果
URLを入力しても404が表示されてアクセスされないようにしました。

## 所感
こういった細かいところに気づけるかがクオリティに繋がると思うので、早い段階で気づけてよかった。

---

## 実装
LINE認証ログインに対するRSpecテストを実装しました。

