### PR TITLE
テキストの改行位置を修正

### DIFF
--- a/app/views/shared/_how_to_use.html.erb
+++ b/app/views/shared/_how_to_use.html.erb
@@ -98,14 +98,19 @@
                             <div class="text-xl text-left font-bold text-green-800 leading-relaxed pb-4">
                                 <ul class="list-disc list-inside space-y-4">
                                     <li>各項目を入力して登録します。</li>
-                                    <li class="list-item-align">カテゴリー”その他”は、次回の<br>
-                                        通知日が2週間後に設定されます。
+                                    <li class="list-item-align">カテゴリー「その他」は、<br>
+                                        次回の通知日が2週間後に<br>
+                                        設定されます。
                                     </li>
-                                    <li class="list-item-align">メモ書きは必須ではないですが、<br>
-                                        登録があると通知や登録確認で<br>
-                                        一緒に表示されます。
+                                    <li class="list-item-align">メモ書きは必須ではない<br>
+                                        ですが、登録があると<br>
+                                        通知や登録確認で一緒に<br>
+                                        表示されます。
                                     </li>
-                                    <li class="list-item-align">カテゴリーアイコンをタップすると、登録内容が確認できます。</li>
+                                    <li class="list-item-align">カテゴリーアイコンを<br>
+                                        タップすると、<br>
+                                        登録内容が確認できます。
+                                    </li>
                                 </ul>
                             </div>
                             <%= image_tag("item_create_form.png", class:"border-2 border-gray-200 shadow-md w-72 h-auto object-contain mx-auto py-4", alt: "item_create") %>
@@ -114,14 +119,16 @@
                 </li>
 
                 <li>
-                    <h2 class="text-3xl text-gray-500 border-b-2 border-gray-200 pb-2">次回通知予定日のみの編集</h2>
+                    <h2 class="text-3xl text-gray-500 border-b-2 border-gray-200 pb-2">次回通知日の編集</h2>
                     <div class="card bg-white shadow-lg p-6">
                         <div class="flex flex-col mt-4">
                             <div class="text-xl font-bold text-green-800 leading-relaxed pb-4">
                                 <ul class="list-disc list-inside space-y-4">
-                                    <li class="list-item-align">　<i class="fas fa-clock text-2xl"></i> から次回通知日を好きな日時に変更できます。</li>
-                                    <li class="list-item-align">通知日までの間隔を自分なりに<br>
-                                        カスタマイズできます。
+                                    <li class="list-item-align">　<i class="fas fa-clock text-2xl"></i> から次回通知日を<br>
+                                        好きな日時に変更できます。
+                                    </li>
+                                    <li class="list-item-align">通知日までの間隔を<br>
+                                        自分なりにカスタマイズできます。
                                     </li>
                                 </ul>
                             </div>
@@ -142,10 +149,10 @@
                                     <li class="list-item-align">「登録確認」<br>
                                         現在の登録の一覧が表示されます。</li>
                                     <li class="list-item-align">「在庫補充」<br>
-                                        通知が来た日用品は、LINE上から<br>
-                                        通知の再設定ができます。<br>
-                                        「在庫補充」と入力した後、続けて<br>
-                                        補充した【商品名】を入力して<br>
+                                        通知が来た日用品は、LINE上から通知の<br>
+                                        再設定ができます。<br>
+                                        「在庫補充」と入力した後、続けて補充した<br>
+                                        【商品名】を入力して<br>
                                         次回通知を再設定してくれます。
                                     </li>
                                 </ul>


### PR DESCRIPTION
- スマホ画面で確認したところ、使い方の解説文章の改行設定が原因で不自然な改行が発生していたので修正しました。本状態はデプロイしないと確認できないので、状態によっては再調整が必要かもしれません。
