### PR TITLE
ボタンをクリックするとピクピクする動作を修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -21,3 +21,8 @@
     background-possition: center;
     min-height: 100vh;
 }
+
+.btn {
+    transition: none !important;
+    transform: none !important;
+}


### PR DESCRIPTION
以下の内容を修正しました。

## 現状
- btn要素を持つ箇所全てに現れていた症状ですが、ボタンをクリックするとピクピクっとヘッダーと使い方のボタンが何かを読み込むような動作をしていました。機能に影響はないのですが、見た目がよろしいとは言えない状態でした。

## 原因
- ブラウザに備わっているデフォルトのアクティブ状態が原因でした。これはユーザーがブラウザ上でボタンを押した時に自動的に適応されるスタイルで、クリックでactiveの状態になった際に動作していたようです。

## 対応
- 最初、TailwindCSSなのでクラスにactive:transform-noneなどと記述したのですが効果なく。application.tailwind.cssにこれを無効化する設定をして対応しました。

