### PR TITLE
Rspecテスト　モデルテストを実装

### DIFF
--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -34,7 +34,7 @@
     </div>
 
     <div class="mb-4 bg-gray-100 p-4 rounded">
-        <%= form.label :used_count_per_weekly, '1週間の使用回数', class: "block text-gray-700 font-bold mb-2" %>
+        <%= form.label :used_count_per_weekly, '一週間の使用回数', class: "block text-gray-700 font-bold mb-2" %>
         <%= form.text_field :used_count_per_weekly, class: "block w-full px-4 py-2 border border-gray-300 rounded shadow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" %>
     </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,8 +4,8 @@ ja:
       item:
         category: "カテゴリー"
         name: "名前"
-        volume: "容量"
-        used_count_per_weekly: "一週間の使用量"
+        volume: "内包量"
+        used_count_per_weekly: "一週間の使用回数"
         memo: "メモ"
       notification:
         next_notification_day: "通知日"
@@ -24,6 +24,8 @@ ja:
             used_count_per_weekly:
               blank: "を入力してください"
               not_a_number: "は数値で入力してください"
+            memo:
+              too_long: "は65,535文字以内で入力してください"
         notification:
           attributes:
             next_notification_day:

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -1,9 +1,0 @@
-FactoryBot.define do
-    factory :item do
-        category { "shampoo" }
-        name { "Test_item" }
-        volume { 300 }
-        used_count_per_weekly { 7 }
-        memo { "test" }
-    end
-end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item do
+    
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     volume { 300 }
     used_count_per_weekly { 7 }
     memo { "test" }
-    association :user
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
-  factory :item do
-    
+  factory :item do      
+    category { "shampoo" }
+    name { "Test_item" }
+    volume { 300 }
+    used_count_per_weekly { 7 }
+    memo { "test" }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,9 +1,10 @@
 FactoryBot.define do
-  factory :item do      
+  factory :item do
     category { "shampoo" }
     name { "Test_item" }
     volume { 300 }
     used_count_per_weekly { 7 }
     memo { "test" }
+    association :user
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :notification do
+    
+  end
+end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :notification do
-    
+    next_notification_day { Date.tomorrow }
+    last_notification_day { Date.yesterday }
+    notification_interval { 14 }
+    association :item
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before { @item = FactoryBot.create(:item) }
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -18,49 +18,49 @@ RSpec.describe Item, type: :model do
     it 'カテゴリーが選択されていない' do
       item = build(:item, user: user, category: nil)
       expect(item).to be_invalid
-      expect(item.errors[:category]).to include("を入力してください")
+      expect(item.errors.full_messages).to include("カテゴリーを入力してください")
     end
 
     it '名前が空欄' do
       item = build(:item, user: user, name: nil)
       expect(item).to be_invalid
-      expect(item.errors[:name]).to include("を入力してください")
+      expect(item.errors.full_messages).to include("名前を入力してください")
     end
 
     it '名前が30文字以上' do
-      item = build(:item, user: user, name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      item = build(:item, user: user, name: "a" * 31)
       expect(item).to be_invalid
-      expect(item.errors[:name]).to include("は30文字以内で入力してください")
+      expect(item.errors.full_messages).to include("名前は30文字以内で入力してください")
     end
 
-    it '内包量が空欄' do
+    it '内包量の入力欄が空' do
       item = build(:item, user: user, volume: nil)
       expect(item).to be_invalid
-      expect(item.errors[:volume]).to include("を入力してください")
+      expect(item.errors.full_messages).to include("内包量を入力してください")
     end
 
-    it '内包量が0である' do
+    it '内包量の値が0である' do
       item = build(:item, user: user, volume: 0)
       expect(item).to be_invalid
-      expect(item.errors[:volume]).to include("は0以外の値にしてください")
+      expect(item.errors.full_messages).to include("内包量は0以外の値にしてください")
     end
 
-    it '一週間の使用回数が空欄' do
+    it '一週間の使用回数の入力欄が空' do
       item = build(:item, user: user, used_count_per_weekly: nil)
       expect(item).to be_invalid
-      expect(item.errors[:used_count_per_weekly]).to include("を入力してください")
+      expect(item.errors.full_messages).to include("一週間の使用回数を入力してください")
     end
 
-    it '一週間の使用回数が0である' do
+    it '一週間の使用回数の値が0である' do
       item = build(:item, user: user, used_count_per_weekly: 0)
       expect(item).to be_invalid
-      expect(item.errors[:used_count_per_weekly]).to include("は0以外の値にしてください")
+      expect(item.errors.full_messages).to include("一週間の使用回数は0以外の値にしてください")
     end
 
-    it '一週間の使用回数が全角文字' do
+    it '一週間の使用回数の値が全角' do
       item = build(:item, user: user, used_count_per_weekly: "１")
       expect(item).to be_invalid
-      expect(item.errors[:used_count_per_weekly]).to include("は数値で入力してください")
+      expect(item.errors.full_messages).to include("一週間の使用回数は数値で入力してください")
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,67 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-  before { @item = FactoryBot.create(:item) }
+  before do
+    mock_auth_hash
+  end
+
+  describe 'バリデーションチェック' do
+    let(:auth) { OmniAuth.config.mock_auth[:line] }
+    let!(:user) { User.from_omniauth(auth) }
+
+    it '設定したすべてのバリデーションが機能しているか' do
+      item = build(:item, user: user)
+      expect(item).to be_valid
+      expect(item.errors).to be_empty
+    end
+
+    it 'カテゴリーが選択されていない' do
+      item = build(:item, user: user, category: nil)
+      expect(item).to be_invalid
+      expect(item.errors[:category]).to include("を入力してください")
+    end
+
+    it '名前が空欄' do
+      item = build(:item, user: user, name: nil)
+      expect(item).to be_invalid
+      expect(item.errors[:name]).to include("を入力してください")
+    end
+
+    it '名前が30文字以上' do
+      item = build(:item, user: user, name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+      expect(item).to be_invalid
+      expect(item.errors[:name]).to include("は30文字以内で入力してください")
+    end
+
+    it '内包量が空欄' do
+      item = build(:item, user: user, volume: nil)
+      expect(item).to be_invalid
+      expect(item.errors[:volume]).to include("を入力してください")
+    end
+
+    it '内包量が0である' do
+      item = build(:item, user: user, volume: 0)
+      expect(item).to be_invalid
+      expect(item.errors[:volume]).to include("は0以外の値にしてください")
+    end
+
+    it '一週間の使用回数が空欄' do
+      item = build(:item, user: user, used_count_per_weekly: nil)
+      expect(item).to be_invalid
+      expect(item.errors[:used_count_per_weekly]).to include("を入力してください")
+    end
+
+    it '一週間の使用回数が0である' do
+      item = build(:item, user: user, used_count_per_weekly: 0)
+      expect(item).to be_invalid
+      expect(item.errors[:used_count_per_weekly]).to include("は0以外の値にしてください")
+    end
+
+    it '一週間の使用回数が全角文字' do
+      item = build(:item, user: user, used_count_per_weekly: "１")
+      expect(item).to be_invalid
+      expect(item.errors[:used_count_per_weekly]).to include("は数値で入力してください")
+    end
+  end
+
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Item, type: :model do
       expect(item.errors.full_messages).to include("名前は30文字以内で入力してください")
     end
 
+    it '名前が重複' do
+      item_first = create(:item, user: user)
+      item_second = build(:item, user: user, name: "Test_item")
+      expect(item_second).to be_invalid
+      expect(item_second.errors.full_messages).to include("名前はすでに存在しています。重複しないようにしてください")
+    end
+
     it '内包量の入力欄が空' do
       item = build(:item, user: user, volume: nil)
       expect(item).to be_invalid
@@ -61,6 +68,19 @@ RSpec.describe Item, type: :model do
       item = build(:item, user: user, used_count_per_weekly: "１")
       expect(item).to be_invalid
       expect(item.errors.full_messages).to include("一週間の使用回数は数値で入力してください")
+    end
+
+    it 'メモが65535文字以上入力されている' do
+      memo = Faker::Lorem.characters(number: 65_536)
+      item = build(:item, user: user, memo: memo)
+      expect(item).to be_invalid
+      expect(item.errors.full_messages).to include("メモは65,535文字以内で入力してください")
+    end
+
+    it 'メモは空欄でも有効' do
+      item = build(:item, user: user, memo: nil)
+      expect(item).to be_valid
+      expect(item.errors).to be_empty
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,72 +15,82 @@ RSpec.describe Item, type: :model do
       expect(item.errors).to be_empty
     end
 
-    it 'カテゴリーが選択されていない' do
-      item = build(:item, user: user, category: nil)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("カテゴリーを入力してください")
+    context 'カテゴリーのバリデーション' do
+      it 'カテゴリーが選択されていない' do
+        item = build(:item, user: user, category: nil)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("カテゴリーを入力してください")
+      end
     end
 
-    it '名前が空欄' do
-      item = build(:item, user: user, name: nil)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("名前を入力してください")
+    context '名前のバリデーション' do
+      it '名前が空欄' do
+        item = build(:item, user: user, name: nil)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("名前を入力してください")
+      end
+
+      it '名前が30文字以上' do
+        item = build(:item, user: user, name: "a" * 31)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("名前は30文字以内で入力してください")
+      end
+
+      it '名前が重複' do
+        item_first = create(:item, user: user)
+        item_second = build(:item, user: user, name: "Test_item")
+        expect(item_second).to be_invalid
+        expect(item_second.errors.full_messages).to include("名前はすでに存在しています。重複しないようにしてください")
+      end
     end
 
-    it '名前が30文字以上' do
-      item = build(:item, user: user, name: "a" * 31)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("名前は30文字以内で入力してください")
+    context '内包量のテスト' do
+      it '内包量の入力欄が空' do
+        item = build(:item, user: user, volume: nil)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("内包量を入力してください")
+      end
+
+      it '内包量の値が0である' do
+        item = build(:item, user: user, volume: 0)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("内包量は0以外の値にしてください")
+      end
     end
 
-    it '名前が重複' do
-      item_first = create(:item, user: user)
-      item_second = build(:item, user: user, name: "Test_item")
-      expect(item_second).to be_invalid
-      expect(item_second.errors.full_messages).to include("名前はすでに存在しています。重複しないようにしてください")
+    context '一週間の使用回数のテスト' do
+      it '一週間の使用回数の入力欄が空' do
+        item = build(:item, user: user, used_count_per_weekly: nil)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("一週間の使用回数を入力してください")
+      end
+
+      it '一週間の使用回数の値が0である' do
+        item = build(:item, user: user, used_count_per_weekly: 0)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("一週間の使用回数は0以外の値にしてください")
+      end
+
+      it '一週間の使用回数の値が全角' do
+        item = build(:item, user: user, used_count_per_weekly: "１")
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("一週間の使用回数は数値で入力してください")
+      end
     end
 
-    it '内包量の入力欄が空' do
-      item = build(:item, user: user, volume: nil)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("内包量を入力してください")
-    end
+    context 'メモのテスト' do
+      it 'メモが65535文字以上入力されている' do
+        memo = Faker::Lorem.characters(number: 65_536)
+        item = build(:item, user: user, memo: memo)
+        expect(item).to be_invalid
+        expect(item.errors.full_messages).to include("メモは65,535文字以内で入力してください")
+      end
 
-    it '内包量の値が0である' do
-      item = build(:item, user: user, volume: 0)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("内包量は0以外の値にしてください")
-    end
-
-    it '一週間の使用回数の入力欄が空' do
-      item = build(:item, user: user, used_count_per_weekly: nil)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("一週間の使用回数を入力してください")
-    end
-
-    it '一週間の使用回数の値が0である' do
-      item = build(:item, user: user, used_count_per_weekly: 0)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("一週間の使用回数は0以外の値にしてください")
-    end
-
-    it '一週間の使用回数の値が全角' do
-      item = build(:item, user: user, used_count_per_weekly: "１")
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("一週間の使用回数は数値で入力してください")
-    end
-
-    it 'メモが65535文字以上入力されている' do
-      memo = Faker::Lorem.characters(number: 65_536)
-      item = build(:item, user: user, memo: memo)
-      expect(item).to be_invalid
-      expect(item.errors.full_messages).to include("メモは65,535文字以内で入力してください")
-    end
-
-    it 'メモは空欄でも有効' do
-      item = build(:item, user: user, memo: nil)
-      expect(item).to be_valid
-      expect(item.errors).to be_empty
+      it 'メモは空欄でも有効' do
+        item = build(:item, user: user, memo: nil)
+        expect(item).to be_valid
+        expect(item.errors).to be_empty
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -63,5 +63,4 @@ RSpec.describe Item, type: :model do
       expect(item.errors[:used_count_per_weekly]).to include("は数値で入力してください")
     end
   end
-
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,5 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Notification, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    let(:notification) { build(:notification) }
+
+    it '設定したすべてのバリデーションが機能しているか' do
+      expect(notification).to be_valid
+      expect(notification.errors).to be_empty
+    end
+
+    it '次回通知予定日が今日' do
+      notification = build(:notification, next_notification_day: Date.today)
+      expect(notification).to be_invalid
+      expect(notification.errors.full_messages).to include('通知日は今日以降の日付を入力してください')
+    end
+
+    it '次回通知予定日が空欄' do
+      notification = build(:notification, next_notification_day: nil)
+      expect(notification).to be_invalid
+      expect(notification.errors.full_messages).to include('通知日を入力してください')
+    end
+
+    it '次回通知予定日が365日以上先' do
+      notification = build(:notification, next_notification_day: Date.today + 366.days)
+      expect(notification).to be_invalid
+      expect(notification.errors.full_messages).to include('通知日は１年以内の日付を入力してください')
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,15 +3,13 @@ require "rails_helper"
 RSpec.describe User, type: :model do
     describe 'LINE認証データからユーザーを作成' do
         before do
-            # OmniAuthのモックデータを使って、ユーザーを作成
             mock_auth_hash
-            @user = User.from_omniauth(auth)
         end
         let(:auth) { OmniAuth.config.mock_auth[:line] }
 
         context 'ユーザー情報が登録されていない' do
-            it 'ユーザー作成' do
-                user = @user
+            let(:user) { User.from_omniauth(auth) }
+            it 'ユーザー新規登録する' do
                 expect(user).to be_persisted # DBに存在しているか
                 expect(user.email).to eq('test@example.com')
                 expect(user.name).to eq('Test User')
@@ -22,9 +20,9 @@ RSpec.describe User, type: :model do
 
         context 'すでにユーザー情報が登録されている' do
             it '既存のユーザーを取得する' do
-                user = @user
-                expect(user).to be_persisted
-                expect(user).to eq(user)
+                first_user = User.from_omniauth(auth)
+                second_user = User.from_omniauth(auth)
+                expect(first_user).to eq(second_user)
             end
         end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,15 +2,17 @@ require "rails_helper"
 
 RSpec.describe User, type: :model do
     describe 'LINE認証データからユーザーを作成' do
-        before { mock_auth_hash }
+        before do
+            # OmniAuthのモックデータを使って、ユーザーを作成
+            mock_auth_hash
+            @user = User.from_omniauth(auth)
+        end
         let(:auth) { OmniAuth.config.mock_auth[:line] }
 
         context 'ユーザー情報が登録されていない' do
             it 'ユーザー作成' do
-                # OmniAuthのモックデータを使って、ユーザーを作成
-                user = User.from_omniauth(auth)
-                # ユーザーが正しく作成されているか確認
-                expect(user).to be_persisted
+                user = @user
+                expect(user).to be_persisted # DBに存在しているか
                 expect(user.email).to eq('test@example.com')
                 expect(user.name).to eq('Test User')
                 expect(user.provider).to eq('line')
@@ -20,8 +22,9 @@ RSpec.describe User, type: :model do
 
         context 'すでにユーザー情報が登録されている' do
             it '既存のユーザーを取得する' do
-                user = User.from_omniauth(auth)
-                expect( User.from_omniauth(auth) ).to eq(user)
+                user = @user
+                expect(user).to be_persisted
+                expect(user).to eq(user)
             end
         end
     end

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -7,7 +7,7 @@ module OmniauthMacros
                 email: 'test@example.com',
                 name: 'Test User'
             },
-            credentials: { 
+            credentials: {
                 token: 'mock_token',
                 refresh_token: 'mock_refresh_token',
                 expires_at: Time.now + 1.week


### PR DESCRIPTION
以下の内容のモデルテストを設定しました。

## 設定
- item
- notification

## 所感
基本的に、カリキュラムや他の人の実装コードなどを参考にしたのですが、特に複雑だったのがユーザー情報をitemのモデルスペックで取得する際にassociation :userが使えなかったこと。

user情報はモックデータで定義しているので、他のクラスのモックデータはlet!(:user)で必ず作成しないといけないということを知った。
