### PR TITLE
rspecテスト エラーを修正

### DIFF
--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Item, type: :model do
         item_first = create(:item, user: user)
         item_second = build(:item, user: user, name: "Test_item")
         expect(item_second).to be_invalid
-        expect(item_second.errors.full_messages).to include("名前はすでに存在しています。重複しないようにしてください")
+        expect(item_second.errors.full_messages).to include("名前はすでに登録されています。重複しないようにしてください")
       end
     end
 

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Items', type: :system do
                 fill_in 'item[used_count_per_weekly]', with: '7'
                 fill_in 'item[memo]', with: 'test'
                 click_button '更新'
-                expect(page).to have_content '名前はすでに存在しています。重複しないようにしてください'
+                expect(page).to have_content '名前はすでに登録されています。重複しないようにしてください'
             end
         end
     end


### PR DESCRIPTION
新規登録をする際、自分以外のユーザーが登録した【商品名】とかぶった時にバリデーションが働いてしまう不具合を修正した結果、rspecのinclude()の結果メッセージの修正を忘れていたため、変更しました。
