### PR TITLE
13 rspec

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+    factory :user do
+        uid { "12345" } 
+        email { "test@example.com" }
+        name { "Test User" }
+        password { "12345678909876543212" }
+    end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Item, type: :model do
     mock_auth_hash
   end
   let(:auth) { OmniAuth.config.mock_auth[:line] }
-  let!(:user) { User.from_omniauth(auth) }
+  let(:user) { User.from_omniauth(auth) }
 
   describe 'バリデーションチェック' do
     it '設定したすべてのバリデーションが機能しているか' do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Notification, type: :model do
     mock_auth_hash
   end
   let(:auth) { OmniAuth.config.mock_auth[:line] }
-  let!(:user) { User.from_omniauth(auth) }
+  let(:user) { User.from_omniauth(auth) }
   let(:item) { create(:item, user: user)}
   let(:notification) { build(:notification) }
 

--- a/spec/requests/linebot_spec.rb
+++ b/spec/requests/linebot_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+include Line::ClientConcern
+
+RSpec.describe "LinebotController", type: :request do
+  before do
+    mock_auth_hash
+  end
+
+  let(:auth) { OmniAuth.config.mock_auth[:line] }
+  let(:user)  { User.from_omniauth(auth) }
+  let(:user_id) { '12345' }
+
+  before do
+    allow_any_instance_of(LinebotController).to receive(:client).and_return(client)
+  end
+
+  describe 'handle_message_eventについて' do
+    let(:event) do
+      event_hash = {
+        'type' => 'message',
+        'message' => { 'text' => message_text },
+        'source' => { 'userId' => user_id }
+      }
+
+      event_double = double(
+        'Line::Bot::Event::Message',
+        type: 'message',
+        message: { 'text' => message_text },
+        source: { 'userId' => user_id }
+      )
+      # `[]` メソッドをモック化
+      allow(event_double).to receive(:[]).with('type').and_return(event_hash['type'])
+      allow(event_double).to receive(:[]).with('message').and_return(event_hash['message'])
+      allow(event_double).to receive(:[]).with('source').and_return(event_hash['source'])
+      allow(event_double).to receive(:source).and_return(event_hash['source'])
+
+      event_double
+    end
+
+    context '"登録確認"と入力された時' do
+      let(:message_text) { '登録確認' }
+      let(:item) { create(:item, user: user) }
+      let!(:notification) { create(:notification, item: item) }
+
+      it 'get_inventory_listメソッドがitem.nameを返すこと' do
+        controller = LinebotController.new
+        response = controller.send(:handle_message_event, event)
+        expect(response[:type]).to eq('text')
+        expect(response[:text]).to include(item.name)
+      end
+    end
+
+    # MESSAGE_STEPは正常に動作しているものとすること
+    context '"在庫補充"と入力された時' do
+      let(:message_text) { '在庫補充' }
+
+      it '商品名を尋ねるメッセージを返すこと' do
+        controller = LinebotController.new
+        response = controller.send(:handle_message_event, event)
+        expect(response[:type]).to eq('text')
+        expect(response[:text]).to eq('登録している【商品名】を入力してください。')
+      end
+    end
+
+    context '”在庫補充”と入力後、【商品名】の入力をすると在庫補充が成功すること' do
+      let(:message_text) { "#{item.name}" }
+      let(:item) { create(:item, user: user) }
+      let!(:notification) { create(:notification, item: item) }
+
+      it '【商品名】を入力され、在庫補充に成功すること' do
+        controller = LinebotController.new
+        response = controller.send(:handle_message_event, event)
+        expect(response[:type]).to eq('text')
+        expect(response[:text]).to include("#{item.name}を補充しました。\n次回通知日は#{item.notification.next_notification_day + 49.days}です。")
+      end
+    end
+  end
+end

--- a/spec/support/omniauth_macros.rb
+++ b/spec/support/omniauth_macros.rb
@@ -5,7 +5,8 @@ module OmniauthMacros
             uid: '12345',
             info: {
                 email: 'test@example.com',
-                name: 'Test User'
+                name: 'Test User',
+                password: '12345678909876543212'
             },
             credentials: {
                 token: 'mock_token',

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Items', type: :system do
     end
 
     let(:auth) { OmniAuth.config.mock_auth[:line] }
-    let!(:user) { User.from_omniauth(auth) }
+    let(:user) { User.from_omniauth(auth) }
     let(:item) { create(:item, user: user, name: 'Another_item') }
 
     describe '日用品の新規登録画面' do


### PR DESCRIPTION
以下の内容を実装しました。

Rspecテスト
- Linebot機能　”登録確認”と入力された時の処理に成功する
- Linebot機能　”在庫補充”と入力されると商品名を聞き返し、登録された商品名と一致した場合次回通知予定日を更新する処理に成功する

### 実装ポイント
- Test Doubleの実装
Linebotコントローラー内ではAPI通信による外部通信で取得したデータが処理に大きく関わってくる。そのためモックデータをLINE Webhook_URLの際のJSON形式で定義できるようにしたり、allowでTest Doubleを定義する際にエラーが出ないようにするのに苦労した。
Test Doubleにも種類があることや、その選び方、使い方などを学んだ。

- close #190 
- close #189 
