### PR TITLE
notification_spec モデルテストを修正

### DIFF
--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :notification do
-    next_notification_day { Date.tomorrow }
-    last_notification_day { Date.yesterday }
-    notification_interval { 1 }
+    next_notification_day { Date.today + 7.days }
+    last_notification_day { Date.today - 7.days }
+    notification_interval { 14 }
     association :item
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -34,8 +34,11 @@ RSpec.describe Notification, type: :model do
     end
   end
 
-  describe '通知メッセージ' do
-    it '作成に成功する' do
+  describe '通知メッセージの作成' do
+    let!(:notification) { create(:notification, item: item) }
+
+    it '成功する' do
+      allow(notification).to receive(:next_notification_day).and_return(Date.today)
       created_message = "商品名【Test_item】の在庫補充をしてください。\n"\
                         "カテゴリー : シャンプー\n" \
                         "メモ書きがあります。\n" \

--- a/spec/requests/linebot_spec.rb
+++ b/spec/requests/linebot_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "LinebotController", type: :request do
         controller = LinebotController.new
         response = controller.send(:handle_message_event, event)
         expect(response[:type]).to eq('text')
-        expect(response[:text]).to include("#{item.name}を補充しました。\n次回通知日は#{item.notification.next_notification_day + 49.days}です。")
+        expect(response[:text]).to include("#{item.name}を補充しました。\n次回通知日は#{item.notification.next_notification_day + 43.days}です。")
       end
     end
   end


### PR DESCRIPTION
以下の内容を修正しました。

## 現状
- ファクトリーボットのnext_notification_dayの日付がDate.tomorrowになっている。作業中に日を跨いだ場合、Date.tomorrowの日付が今日になってしまい、バリデーション に引っかかってしまう。
- notificationモデルテスト内で、メッセージ作成の成功テストの内容が不十分だった。

## 対応
- ファクトリーボットのnext_notification_dayをDate.today + 7.daysと変更しました。
- ファクトリーボットでnotificationをcreateした後、allowで「notificationがnext_notification_dayを受け取る際、Date.todayとして返す」ことを定義することでバリデーションをかわすように調整

## 所感
テスト中、突然大量のrspecエラーが発生したときは焦った。こういったリスク管理は大切と感じた。
allowの強さを改めて実感。
