### PR TITLE
使い方の説明文の改行箇所を修正

### DIFF
--- a/app/views/shared/_how_to_use.html.erb
+++ b/app/views/shared/_how_to_use.html.erb
@@ -19,12 +19,9 @@
                             <div class="text-xl font-bold text-green-800 w-1/2 leading-relaxed">
                                 <ul class="list-disc list-inside space-y-4">
                                     <li>各項目を入力して登録します。</li>
-                                    <li class="list-item-align">カテゴリー”その他”は、次回の<br>
-                                        通知日が2週間後に設定されます。
+                                    <li class="list-item-align">カテゴリー”その他”は、次回の通知日が2週間後に設定されます。
                                     </li>
-                                    <li class="list-item-align">メモ書きは必須ではないですが、<br>
-                                        登録があると通知や登録確認で<br>
-                                        一緒に表示されます。
+                                    <li class="list-item-align">メモは必須ではないですが、登録があると通知や登録確認で一緒に表示されます。
                                     </li>
                                     <li class="list-item-align">カテゴリーアイコンをタップすると、登録内容が確認できます。</li>
                                 </ul>
@@ -40,11 +37,9 @@
                         <div class="flex items-center gap-6 mt-4">
                             <div class="text-xl font-bold text-green-800 w-1/2 leading-relaxed">
                                 <ul class="list-disc list-inside space-y-4">
-                                    <li class="list-item-align">　<i class="fas fa-clock text-2xl"></i> から次回通知日を<br>
-                                        好きな日時に変更できます。
+                                    <li class="list-item-align">　<i class="fas fa-clock text-2xl"></i> から次回通知日を好きな日時に変更できます。
                                     </li>
-                                    <li class="list-item-align">通知日までの間隔を自分なりに<br>
-                                        カスタマイズできます。
+                                    <li class="list-item-align">通知日までの間隔を自分なりにカスタマイズできます。
                                     </li>
                                 </ul>
                             </div>
@@ -60,20 +55,14 @@
                             <div class="text-xl font-bold text-green-800 w-1/2 leading-relaxed">
                                 <ul class="list-disc list-inside space-y-4">
                                     <li class="list-item-align">アプリから通知<br>
-                                        通知日になると、アプリから<br>
-                                        ユーザーのLINEに登録した内容が<br>
-                                        送信されます。
+                                        通知日になると、アプリからユーザーのLINEに登録した内容が送信されます。
                                     </li>
                                     <li class="list-item-align">「登録確認」<br>
                                         現在の登録の一覧が表示されます。
                                     </li>
                                     <li class="list-item-align">「在庫補充」<br>
-                                        通知が来た日用品は、LINE上から<br>
-                                        通知の再設定ができます。<br>
-                                        「在庫補充」と入力した後、<br>
-                                        続けて登録した【商品名】を<br>
-                                        入力することで次回通知を<br>
-                                        再設定してくれます。
+                                        通知が来た日用品は、LINE上から通知の再設定ができます。<br>
+                                        「在庫補充」と入力した後、続けて登録した【商品名】を入力することで次回通知を再設定してくれます。
                                     </li>
                                 </ul>
                             </div>
@@ -101,7 +90,7 @@
                                     <li class="list-item-align">カテゴリー「その他」は、次回の通知日が<br>
                                         2週間後に設定されます。
                                     </li>
-                                    <li class="list-item-align">メモ書きは必須ではない<br>
+                                    <li class="list-item-align">メモは必須ではない<br>
                                         ですが、登録があると<br>
                                         通知や登録確認で一緒に<br>
                                         表示されます。


### PR DESCRIPTION
以下の修正をしました。

### 現状
使い方の改行箇所を調整していたのですが、PCの画面サイズによって、不自然な箇所で改行しているなどのレイアウト崩れがありました。

### 修正
一度改行を削除してみたところ、特に問題なさそうだったため改行自体を削除しました。