### PR TITLE
LINE関連の処理をサービスクラスに移動

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -108,21 +108,8 @@ class LinebotController < ApplicationController
         end
     end
 
-    # 登録一覧のメッセージ
     def format_items_message(items)
-        items.map do |item|
-            item_lists = [
-                "商品名: 【#{item.name}】",
-                "カテゴリー: #{I18n.t("categories.#{item.category}", default: item.category)}",
-                "次回通知日: #{item.notification.next_notification_day}"
-            ]
-
-            if item.memo.present?
-                item_lists << "メモ内容: #{item.memo}"
-            end
-
-            item_lists << "-----------------"
-            item_lists.join("\n")
-        end.join("\n")
+        service = LineMessageFormatter.new(items)
+        service.call
     end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,6 +4,7 @@ class Notification < ApplicationRecord
 
   validate :valid_next_notification_day
 
+  # 通知日を計算する処理群
   def item_update_next_notification_day
     new_notification_day = item.calculate_next_notification_day
     interval = (new_notification_day - Date.today).to_i
@@ -17,10 +18,6 @@ class Notification < ApplicationRecord
                 notification_interval: interval)
   end
 
-  def save_last_notification_day
-    self.update(last_notification_day: Date.today)
-  end
-
   def linebot_update_next_notification_day
     interval_days = item.linebot_calculate_next_notification_day
     new_notification_day = Date.today + interval_days
@@ -29,34 +26,15 @@ class Notification < ApplicationRecord
       notification_interval: interval_days)
   end
 
-  def push_line_message
-    user = item&.user
-    line_user_id = user&.uid
-
-    if line_user_id.present?
-      message = self.create_notification_message
-      begin
-        client.push_message(line_user_id, {
-          type: "text",
-          text: message
-        })
-        self.save_last_notification_day
-      rescue => error
-        Rails.logger.error("LINE通知送信エラー: #{error.message}")
-      end
-    else
-      Rails.logger.error("LINE通知送信エラー: UIDが見つかりません(Notification ID: #{self.id})")
-    end
+  def save_last_notification_day
+    self.update(last_notification_day: Date.today)
   end
 
-  def create_notification_message
-    message = "商品名【#{item.name}】の在庫補充をしてください。\n"
-    message += "カテゴリー : #{I18n.t("categories.#{item.category}", default: item.category)}\n"
-    if item.memo.present?
-      message += "メモ書きがあります。\n"
-      message += "メモ内容 : #{item.memo}\n"
-    end
-    message
+
+  # LINE通知を送信する処理群
+  def push_line_message
+    service = LineNotificationService.new(self)
+    service.call
   end
 
   def self.send_notifications
@@ -68,17 +46,17 @@ class Notification < ApplicationRecord
 
   private
 
+  def self.date_of_notification
+    where(next_notification_day: Date.today)
+  end
+
   def valid_next_notification_day
     if next_notification_day.blank?
       errors.add(:next_notification_day, :blank_field)
-    elsif next_notification_day < Date.today + 1.days
+    elsif next_notification_day < Date.today# + 1.days
       errors.add(:next_notification_day, :past_date)
     elsif next_notification_day > Date.today + 365.days
       errors.add(:next_notification_day, :too_far)
     end
-  end
-
-  def self.date_of_notification
-    where(next_notification_day: Date.today)
   end
 end

--- a/app/services/line_message_formatter.rb
+++ b/app/services/line_message_formatter.rb
@@ -11,8 +11,8 @@ class LineMessageFormatter
         end
     end
     # 登録一覧のメッセージ
-    def create_items_message
-        @items.map do |item|
+    def create_items_message(items)
+        items.map do |item|
             item_lists = [
                 "商品名: 【#{item.name}】",
                 "カテゴリー: #{I18n.t("categories.#{item.category}", default: item.category)}",
@@ -27,3 +27,4 @@ class LineMessageFormatter
             item_lists.join("\n")
         end.join("\n")
     end
+end

--- a/app/services/line_message_formatter.rb
+++ b/app/services/line_message_formatter.rb
@@ -4,14 +4,10 @@ class LineMessageFormatter
     end
 
     def call
-        if @items.present?
-            create_items_message(@items)
-        else
-            "登録されている日用品はありません。"
-        end
+        create_items(@items)
     end
     # 登録一覧のメッセージ
-    def create_items_message(items)
+    def create_items(items)
         items.map do |item|
             item_lists = [
                 "商品名: 【#{item.name}】",

--- a/app/services/line_message_formatter.rb
+++ b/app/services/line_message_formatter.rb
@@ -1,0 +1,29 @@
+class LineMessageFormatter
+    def initialize(items)
+        @items = items
+    end
+
+    def call
+        if @items.present?
+            create_items_message(@items)
+        else
+            "登録されている日用品はありません。"
+        end
+    end
+    # 登録一覧のメッセージ
+    def create_items_message
+        @items.map do |item|
+            item_lists = [
+                "商品名: 【#{item.name}】",
+                "カテゴリー: #{I18n.t("categories.#{item.category}", default: item.category)}",
+                "次回通知日: #{item.notification.next_notification_day}"
+            ]
+
+            if item.memo.present?
+                item_lists << "メモ内容: #{item.memo}"
+            end
+
+            item_lists << "-----------------"
+            item_lists.join("\n")
+        end.join("\n")
+    end

--- a/app/services/line_notification_service.rb
+++ b/app/services/line_notification_service.rb
@@ -1,0 +1,43 @@
+class LineNotificationService
+    include Line::ClientConcern
+
+    def initialize(notification)
+        @notification = notification
+    end
+
+    def call
+        push_line_notification(@notification)
+    end
+
+    def push_line_notification(notification)
+        user = @notification.item&.user
+        line_user_id = user&.uid
+
+        if line_user_id.present?
+            message = create_notification_message
+            begin
+                client.push_message(line_user_id, {
+                    type: "text",
+                    text: message
+                })
+                @notification.save_last_notification_day
+            rescue => error
+                Rails.logger.error("LINE通知送信エラー: #{error.message}")
+            end
+        else
+            Rails.logger.error("LINE通知送信エラー: UIDが見つかりません(Notification ID: #{@notification.id})")
+        end
+    end
+
+    def create_notification_message
+        item = @notification.item
+        message = "商品名【#{item.name}】の在庫補充をしてください。\n"
+        message += "カテゴリー : #{I18n.t("categories.#{item.category}", default: item.category)}\n"
+
+        if item.memo.present?
+            message += "メモ書きがあります。\n"
+            message += "メモ内容 : #{item.memo}\n"
+        end
+        message
+    end
+end

--- a/spec/services/line_message_formatter_spec.rb
+++ b/spec/services/line_message_formatter_spec.rb
@@ -1,0 +1,27 @@
+# spec/services/line_message_formatter_spec.rb
+require 'rails_helper'
+
+RSpec.describe LineMessageFormatter, type: :service do
+    before do
+        mock_auth_hash
+    end
+
+    let(:auth) { OmniAuth.config.mock_auth[:line] }
+    let(:user) { User.from_omniauth(auth) }
+    let(:item) { create(:item, user: user) }
+    let!(:notification) { create(:notification, item: item) }
+
+    describe 'line_message_formatterについて' do
+        it '正しくフォーマットされたアイテムリストを返す' do
+            items = [item] # item_listの形式に合わせる
+            line_message_formatter = LineMessageFormatter.new(items)
+            formatted_message = line_message_formatter.create_items(items)
+
+            expect(formatted_message).to include("商品名: 【#{item.name}】")
+            expect(formatted_message).to include("カテゴリー: #{I18n.t("categories.#{item.category}", default: item.category)}")
+            expect(formatted_message).to include("次回通知日: #{item.notification.next_notification_day}")
+            expect(formatted_message).to include("メモ内容: #{item.memo}")
+            expect(formatted_message).to include("-----------------")
+        end
+    end
+end


### PR DESCRIPTION
以下の変更を行いました。また本来はよろしくないのですが、heroku schedulerを本番環境を参照しているしているため、一部が未完成の状態です。確認でき次第、すぐに修正を行います。

# 現状
linebotコントローラーとnotificationモデルには、それぞれの役割のほかにLINEへ通知するメッセージを作成する処理と登録一覧を送信する処理が混在しています。
そこで責任分離の考えから、このコードをサービスクラスに移動させました。

# 修正
- app/servicesディレクトリを作成し、それぞれの処理を移動させるファイルを作成し、編集
- 既存のlinebotコントローラーとnotificationモデルを修正
- linebotコントローラーのRspecテストも修正。
